### PR TITLE
Allow Ctrl clicking nodes in tree view for context menu

### DIFF
--- a/pkg/nuclide/ui/tree/lib/TreeRootComponent.js
+++ b/pkg/nuclide/ui/tree/lib/TreeRootComponent.js
@@ -200,7 +200,7 @@ var TreeRootComponent = React.createClass({
 
   _onMouseDown(event: SyntheticMouseEvent, node: LazyTreeNode): void {
     // Select the node on right-click.
-    if (event.button === 2) {
+    if (event.button === 2 || (event.button === 0 && event.ctrlKey === true)) {
       if (!this._isNodeSelected(node)) {
         this.setState({selectedKeys: new Set([node.getKey()])});
       }

--- a/pkg/nuclide/ui/tree/spec/TreeRootComponent-spec.js
+++ b/pkg/nuclide/ui/tree/spec/TreeRootComponent-spec.js
@@ -258,6 +258,30 @@ describe('TreeRootComponent', () => {
       });
     });
 
+    it('selects node if right clicking or ctrl clicking for context menu', () => {
+      waitsForPromise(async () => {
+        var component = renderComponent(props);
+        component.setRoots([nodes['G']]);
+        await fetchChildrenForNodes(component.getRootNodes());
+
+        expect(component.getSelectedNodes()).toEqual([]);
+
+        var treeNodes = TestUtils.scryRenderedComponentsWithType(
+            component,
+            TreeNodeComponent
+          );
+
+        TestUtils.Simulate.mouseDown(treeNodes[0].getDOMNode(), {button: 2});
+        expect(component.getSelectedNodes()).toEqual([treeNodes[0].props.node]);
+
+        TestUtils.Simulate.mouseDown(treeNodes[1].getDOMNode(), {button: 0, ctrlKey: true});
+        expect(component.getSelectedNodes()).toEqual([treeNodes[1].props.node]);
+
+        TestUtils.Simulate.mouseDown(treeNodes[2].getDOMNode(), {button: 0});
+        expect(component.getSelectedNodes()).toEqual([treeNodes[1].props.node]);
+      });
+    });
+
     it('does not toggle whether node is selected if click is on the arrow', () => {
       waitsForPromise(async () => {
         var component = renderComponent(props);


### PR DESCRIPTION
I noticed that when I ctrl-clicked folders to create files, it wasn't selecting the folder like Atom's default tree view like I expected.
