### PR TITLE
Modify .gitignore

### DIFF
--- a/pkg/.gitignore
+++ b/pkg/.gitignore
@@ -1,3 +1,3 @@
 .DS_Store
-npm-debug.log
+npm-debug.log*
 node_modules


### PR DESCRIPTION
Ignore npm-debug.log\* instead of npm-debug.log

I got `nuclide/task/npm-debug.log.64c2c71859575613623585c049243533`.
It is not matched with `npm-debug.log`.
