### PR TITLE
Set inline image heights to prevent reflow on load

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <div class="headerContainer">
   <div id="header_wrap" class="wrapper headerWrapper">
     <div class="inner">
-      <img class="projectLogo" height="200px" src="{{ site.baseurl }}/static/logo.png" alt="{{ site.title }}" title="{{ site.title }}" />
+      <img class="projectLogo" height="200" src="{{ site.baseurl }}/static/logo.png" alt="">
       <h1 id="project_title">{{ site.title }}</h1>
       <h2 id="project_tagline" class="fbossFontLight">{{ site.tagline }}</h2>
 

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,6 +1,9 @@
 <div id="fixed_header" class="fixedHeaderContainer{% if include.alwayson %} visible{% endif %}">
   <header>
-    <a href="{{ site.url }}{{ site.baseurl }}"><img src="{{ site.baseurl }}/static/logo.png" /><h2>{{ site.title }}</h2></a>
+    <a href="{{ site.url }}{{ site.baseurl }}">
+      <img src="{{ site.baseurl }}/static/logo.png" height="30" width="25" alt="">
+      <h2>{{ site.title }}</h2>
+    </a>
     <div class="navigationWrapper navigationFull" id="flat_nav">
       <nav class="navigation">
         <ul>


### PR DESCRIPTION
- When loading over a slow network, the nav links align left and then
  jump to the right when the dimensions of the img are determined. Set
  final height/width to prevent.
- Since both images immediately precede the 'Nuclide' title, `alt`
  doesn't need to be set.
