### PR TITLE
Enable Nuclide Server to listen on connections over both IPv4 and IPv6

### DIFF
--- a/pkg/nuclide/server/lib/NuclideServer.js
+++ b/pkg/nuclide/server/lib/NuclideServer.js
@@ -303,7 +303,7 @@ class NuclideServer {
         this._webServer.removeAllListeners();
         reject(e);
       });
-      this._webServer.listen(this._port, '::');
+      this._webServer.listen(this._port);
     });
   }
 


### PR DESCRIPTION
Currently when trying to run Nuclide server on an OS that does not support IPv6 (in this case an old version of Linux) the server will fail to start with this error message:

```
Error: listen EAFNOSUPPORT
```

Some digging online indicated this was likely related to the OS not supporting IPv6. I removed the second argument as shown in this patch and then the server started fine. I was also able to connect from Nuclide no problem.

I *believe* this change will allow connections over both IPv4 and IPv6 on the specified port. I'm not too familiar with Node's implementation of listen() but I know there are differences between Linux, other Unixes and Windows on how listen() is handled when it comes to IPv4 and IPv6. This patch may be insufficient to allow connections over both IPv4 and IPv6 in those environments, but I don't have any Windows/Other Unixes available to test with at the moment.