### PR TITLE
Use mv instead of fs.rename so that cross-device renames do not fail with EXDEV

### DIFF
--- a/pkg/nuclide/node-transpiler/lib/babel-cache.js
+++ b/pkg/nuclide/node-transpiler/lib/babel-cache.js
@@ -15,6 +15,7 @@ var crypto = require('crypto');
 var fs = require('fs');
 var path = require('path');
 var temp = require('temp').track();
+var mv = require('mv');
 var cacheDir = createCacheDir();
 
 /**
@@ -92,7 +93,7 @@ function createOrFetchFromCache(sourceCode, filePath) {
         return;
       }
 
-      fs.rename(info.path, transpiledFile);
+      mv(info.path, transpiledFile, {mkdirp: true});
     });
   });
 

--- a/pkg/nuclide/node-transpiler/package.json
+++ b/pkg/nuclide/node-transpiler/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "babel-core": "5.5.4",
     "babel-runtime": "5.5.4",
+    "mv": "^2.1.1",
     "temp": "0.8.1"
   }
 }


### PR DESCRIPTION
This adds a new dependency on the mv module.
Fixes #88 