### PR TITLE
Allow the flow linter to run under the source.js.jsx scope

### DIFF
--- a/pkg/nuclide/flow/lib/FlowLinter.js
+++ b/pkg/nuclide/flow/lib/FlowLinter.js
@@ -78,7 +78,7 @@ function processDiagnostics(diagnostics: Array<Object>, targetFile: string) {
 }
 
 module.exports = {
-  grammarScopes: ['source.js'],
+  grammarScopes: ['source.js', 'source.js.jsx'],
   scope: 'file',
   lintOnFly: true,
   async lint(textEditor: TextEditor): Promise<Array<Object>> {


### PR DESCRIPTION
Currently, the flow linter only runs on the `source.js` grammar scope. However, multiple packages that provide JSX syntax highlighting use the `source.js.jsx` scope:

- https://github.com/orktes/atom-react
- https://github.com/subtleGradient/language-javascript-jsx
- https://atom.io/packages/language-babel

There are [other scopes](https://github.com/AtomLinter/linter-eslint/blob/master/lib/linter-eslint.coffee#L36) that the linter could support but the JSX one seemed like the most important.
