### PR TITLE
Add Gemfile and directions for running site locally 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,6 @@
-.DS_STORE
+.sass-cache/
 _site/
-Gemfile
-Gemfile.lock
-*.swo
-*.swp
-_site
-.sass-cache
-*.psd
-*~
 
+# Ignore locked gems because GitHub Pages controls the gems in production, not Nuclide. Omit the
+# lock so `bundle install` always installs the latest.
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'github-pages'

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # nuclide.io
+
+### Run the Site Locally
+
+1. Make sure you Ruby and [RubyGems](https://rubygems.org/) installed
+2. Make sure you have [Bundler](http://bundler.io/) installed
+
+      gem install bundler
+3. Install the project's dependencies
+
+      bundle install
+4. Run Jekyll's server
+
+      bundle exec jekyll serve

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 1. Make sure you Ruby and [RubyGems](https://rubygems.org/) installed
 2. Make sure you have [Bundler](http://bundler.io/) installed
 
-      gem install bundler
+        gem install bundler
 3. Install the project's dependencies
 
-      bundle install
+        bundle install
 4. Run Jekyll's server
 
-      bundle exec jekyll serve
+        bundle exec jekyll serve

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Run the Site Locally
 
-1. Make sure you Ruby and [RubyGems](https://rubygems.org/) installed
+1. Make sure you have Ruby and [RubyGems](https://rubygems.org/) installed
 2. Make sure you have [Bundler](http://bundler.io/) installed
 
         gem install bundler


### PR DESCRIPTION
- Remove `Gemfile` from ignored files so users can do `bundle install`
  locally. `Gemfile.lock` intentionally still ignored because prod is
  controlled by GitHub Pages, not by this repo.
- Leave only files generated by tools in this repo in .gitignore. Files
  created by a user's platform (like .DS_Store) should be added to a
  user's `.gitignore` in their home directory.
