### PR TITLE
cleared up confusing error message inside nuclide-diff-view

### DIFF
--- a/pkg/nuclide/diff-view/lib/DiffViewModel.js
+++ b/pkg/nuclide/diff-view/lib/DiffViewModel.js
@@ -38,7 +38,7 @@ class DiffViewModel {
     }
     var repository = await atom.project.repositoryForDirectory(rootDirectory);
     if (!repository || repository.getType() !== 'hg') {
-      throw new Error('Diff view only supports hg repositories right now: ' + repository && repository.getType());
+      throw new Error('Diff view only supports hg repositories right now: ' + (repository && repository.getType()));
     }
     var committedContents = await repository.fetchFileContentAtRevision(this._filePath);
 

--- a/pkg/nuclide/diff-view/lib/DiffViewModel.js
+++ b/pkg/nuclide/diff-view/lib/DiffViewModel.js
@@ -38,7 +38,7 @@ class DiffViewModel {
     }
     var repository = await atom.project.repositoryForDirectory(rootDirectory);
     if (!repository || repository.getType() !== 'hg') {
-      throw new Error('Diff view only supports hg repositories right now: ' + (repository && repository.getType()));
+      throw new Error('Diff view only supports hg repositories right now: found ' + (repository && repository.getType()));
     }
     var committedContents = await repository.fetchFileContentAtRevision(this._filePath);
 


### PR DESCRIPTION
When trying to diff any files in my project, I'd get: 

```
Cannot open diff view for file: /Users/dallin/code/kualico/cm/server/resources/workflow/types/types.js
Error: git
```

Which made me think nuclide wasn't able to find my git binary. This change makes that error message a little clearer: 

```
Cannot open diff view for file: /Users/dallin/code/kualico/cm/server/resources/workflow/types/types.js
Error: Diff view only supports hg repositories right now: git
```