### PR TITLE
Fix nuclide-start-server certificate validation

### DIFF
--- a/pkg/nuclide/server/scripts/nuclide_server.py
+++ b/pkg/nuclide/server/scripts/nuclide_server.py
@@ -77,7 +77,7 @@ class NuclideServer(object):
             server_cert, server_key, ca = self.get_server_certificate_files()
             client_cert, client_key = self.get_client_certificate_files(ca)
             self._version = utils.http_get('localhost', self.port, method='POST', url='/server/version',
-                                           key_file=client_key, cert_file=client_cert)
+                                           key_file=client_key, cert_file=client_cert, ca_cert = ca)
         else:
             self._version = utils.http_get('localhost', self.port, method='POST', url='/server/version')
         return self._version


### PR DESCRIPTION
The version check was failing due to certificate validation failures.
Fix this by:
- disabling host name validation
- passing the CA cert file to the client for validation

Also adds printing for unexpected SSL errors