### PR TITLE
Added alt-click functionality to the file tree

### DIFF
--- a/pkg/nuclide/ui/tree/lib/TreeRootComponent.js
+++ b/pkg/nuclide/ui/tree/lib/TreeRootComponent.js
@@ -65,6 +65,18 @@ function toggleSetHas(
   return added;
 }
 
+function isPathIgnored(path: string): boolean {
+  var isIgnored = false;
+  atom.project.getRepositories().forEach(repo => {
+    if(!repo) {
+      return;
+    }
+    if(repo.isPathIgnored(path)) {
+      isIgnored = true;
+    }
+  });
+  return isIgnored;
+}
 var FIRST_SELECTED_DESCENDANT_REF: string = 'firstSelectedDescendant';
 
 /**
@@ -178,6 +190,35 @@ var TreeRootComponent = React.createClass({
     this.setState({expandedKeys});
   },
 
+  async _toggleChildNodesExpanded(parentNode: LazyTreeNode, forceExpanded: ?boolean): Promise {
+    if(isPathIgnored(parentNode.getItem().getPath())) {
+      return;
+    };
+    var childNodes = parentNode.getCachedChildren();
+
+    // fetch children if cache is empty
+    if(!childNodes) {
+      await parentNode.fetchChildren().then(nodes => childNodes = nodes);
+    }
+
+    // exit if cache is still empty
+    if(!childNodes) {
+      return;
+    }
+
+    // filter directories only and expand/collapse nodes
+    childNodes
+    .filter(childNode => childNode.getItem().isDirectory())
+    .forEach(childNode => {
+      if(isPathIgnored(childNode.getItem().getPath())) {
+        return;
+      };
+
+      this._toggleChildNodesExpanded(childNode)
+      .then(() => this._toggleNodeExpanded(childNode, forceExpanded));
+    });
+  },
+
   _toggleNodeSelected(node: LazyTreeNode, forceSelected?: ?boolean): void {
     var selectedKeys = this.state.selectedKeys;
     toggleSetHas(selectedKeys, node.getKey(), forceSelected);
@@ -205,7 +246,14 @@ var TreeRootComponent = React.createClass({
   },
 
   _onClickNodeArrow(event: SyntheticEvent, node: LazyTreeNode): void {
-    this._toggleNodeExpanded(node);
+    // if alt-clicked the arrow, expand child directories
+    if(event.altKey) {
+      // show/hide child nodes when clicked
+      this._toggleChildNodesExpanded(node, !this._isNodeExpanded(node))
+      .then(() => this._toggleNodeExpanded(node));
+    } else {
+      this._toggleNodeExpanded(node);
+    }
   },
 
   _onDoubleClickNode(event: SyntheticMouseEvent, node: LazyTreeNode): void {

--- a/pkg/nuclide/ui/tree/spec/TreeRootComponent-spec.js
+++ b/pkg/nuclide/ui/tree/spec/TreeRootComponent-spec.js
@@ -462,6 +462,40 @@ describe('TreeRootComponent', () => {
         });
       });
 
+      /*
+       * Little bit flaky since the nodes here doesn't
+       * actually represent nodes rendered in Atom.
+       * LazyTestTreeNode is used here while LazyFileTreeNode is used in Atom.
+       */
+      it('toggles child nodes if alt-clicked', () => {
+        waitsForPromise(async () => {
+          var component = renderComponent(props);
+          spyOn(component, '_toggleChildNodesExpanded').andCallFake(() => {
+            return {
+              then: (callback) => callback()
+            };
+          });
+          await component.setRoots([nodes['G']]);
+          expect(component.getExpandedNodes()).toEqual([nodes['G']]);
+
+          var nodeComponents = getNodeComponents(component);
+
+          // Collapse node
+          TestUtils.Simulate.click(React.findDOMNode(nodeComponents['G'].refs['arrow']));
+          expect(component.getExpandedNodes()).toEqual([]);
+
+          // Alt-click node
+          TestUtils.Simulate.click(React.findDOMNode(nodeComponents['G'].refs['arrow']), {altKey: true});
+
+          // expect _toggleChildNodesExpanded to only be called once
+          expect(component._toggleChildNodesExpanded.calls.length).toBe(1);
+        });
+      });
+
+      xit('ignores ignored files when alt-clicking', () => {
+
+      });
+
       it('does not toggle whether node is selected', () => {
         waitsForPromise(async () => {
           var component = renderComponent(props);


### PR DESCRIPTION
Fixes #68 
The test is a little bit flaky since the nodes used in the test doesn't actually represent those used in Atom.