### PR TITLE
Add support for traces

### DIFF
--- a/pkg/nuclide/flow/lib/FlowLinter.js
+++ b/pkg/nuclide/flow/lib/FlowLinter.js
@@ -43,8 +43,8 @@ function extractRange(message){
 function flowMessageToTrace(message){
   return {
     type: 'Trace',
-    text: message.descr,
-    filePath: message.path,
+    text: message['descr'],
+    filePath: message['path'],
     range: extractRange(message),
   };
 }
@@ -53,9 +53,9 @@ function flowMessageToLinterMessage(arr) {
   var message = arr[0];
 
   var obj = {
-    type: message.level || 'Error',
-    text: arr.map( (errObj) => errObj.descr).join(' '),
-    filePath: message.path,
+    type: message['level'] || 'Error',
+    text: arr.map( (errObj) => errObj['descr']).join(' '),
+    filePath: message['path'],
     range: extractRange(message),
   };
 

--- a/pkg/nuclide/flow/lib/FlowLinter.js
+++ b/pkg/nuclide/flow/lib/FlowLinter.js
@@ -76,7 +76,7 @@ function processDiagnostics(diagnostics: Array<Object>, targetFile: string) {
   // Filter messages not addressing `targetFile` and merge messages spanning multiple files.
   return diagnostics
     .map( (diagnostic) => diagnostic['message'] )
-    .filter(hasMessageWithPath);
+    .filter(hasMessageWithPath)
     .map(flowMessageToLinterMessage);
 }
 

--- a/pkg/nuclide/flow/lib/FlowLinter.js
+++ b/pkg/nuclide/flow/lib/FlowLinter.js
@@ -61,7 +61,7 @@ function flowMessageToLinterMessage(arr) {
 
   // When the message is an array with multiple elements
   // The second element onwards make the trace for the error.
-  if(arr.length > 1){
+  if (arr.length > 1){
     obj.trace = arr.slice(1).map(flowMessageToTrace);
   }
 

--- a/pkg/nuclide/flow/spec/FlowLinter-spec.js
+++ b/pkg/nuclide/flow/spec/FlowLinter-spec.js
@@ -1,12 +1,13 @@
 'use babel';
 /* @flow */
-
+/* global describe, it, expect */
 /*
  * Copyright (c) 2015-present, Facebook, Inc.
  * All rights reserved.
  *
  * This source code is licensed under the license found in the LICENSE file in
  * the root directory of this source tree.
+ *
  */
 
 var {Range} = require('atom');
@@ -20,6 +21,7 @@ describe('FlowLinter::processDiagnostics', () => {
       {
         message: [
           {
+            level: 'error',
             path: 'myPath',
             descr: 'message',
             line: 1,
@@ -27,14 +29,43 @@ describe('FlowLinter::processDiagnostics', () => {
             start: 3,
             end: 4,
             code: 0,
-          }
-        ]
-      }
+          },
+        ],
+      },
     ];
 
     var expectedOutput = {
       text: 'message',
-      type: 'Error',
+      type: 'error',
+      filePath: 'myPath',
+      range: new Range([0, 2], [1, 4]),
+    };
+
+    var message = FlowLinter.processDiagnostics(diags, 'myPath')[0];
+    expect(message).toEqual(expectedOutput);
+  });
+
+  it('should keep warnings as warnings', () => {
+    var diags = [
+      {
+        message: [
+          {
+            level: 'warning',
+            path: 'myPath',
+            descr: 'message',
+            line: 1,
+            endline: 2,
+            start: 3,
+            end: 4,
+            code: 0,
+          },
+        ],
+      },
+    ];
+
+    var expectedOutput = {
+      text: 'message',
+      type: 'warning',
       filePath: 'myPath',
       range: new Range([0, 2], [1, 4]),
     };
@@ -55,46 +86,54 @@ describe('FlowLinter::processDiagnostics', () => {
             start: 3,
             end: 4,
             code: 0,
-          }
-        ]
-      }
+          },
+        ],
+      },
     ];
 
     var message = FlowLinter.processDiagnostics(diags, 'myPath')[0];
     expect(message).toBeUndefined();
   });
 
-  it('should merge diagnostic messages spanning files', () => {
+  it('should create traces for diagnostics spanning multiple messages and combine the error text', () => {
     var diags = [
       {
         message: [
           {
+            level: 'error',
             path: 'myPath',
             descr: 'message',
             line: 1,
             endline: 2,
             start: 3,
             end: 4,
-            code: 0
+            code: 0,
           },
           {
-            path: 'notMyPath',
+            level: 'error',
+            path: 'otherPath',
             descr: 'more message',
             line: 5,
             endline: 6,
             start: 7,
             end: 8,
             code: 0,
-          }
-        ]
-      }
+          },
+        ],
+      },
     ];
 
     var expectedOutput = {
-      type: 'Error',
+      type: 'error',
       text: 'message more message',
       filePath: 'myPath',
       range: new Range([0, 2], [1, 4]),
+      trace: [{
+        type: 'Trace',
+        filePath: 'otherPath',
+        text: 'more message',
+        range: new Range([4, 6], [5, 8]),
+      }],
     };
 
     var message = FlowLinter.processDiagnostics(diags, 'myPath')[0];


### PR DESCRIPTION
AtomLinter supports arrays of traces in every error object. So now there is a correct way of dealing with flow errors that span multiple files.