### PR TITLE
[hack] Minor cleanup

### DIFF
--- a/pkg/nuclide/hack/lib/HackLinter.js
+++ b/pkg/nuclide/hack/lib/HackLinter.js
@@ -18,11 +18,6 @@ module.exports = {
   scope: 'file',
   lintOnFly: true,
   async lint(textEditor: TextEditor): Promise<Array<Object>> {
-    var file = textEditor.getBuffer().file;
-    if (!file) {
-      return [];
-    }
-
     var diagnostics = await findDiagnostics(textEditor);
     return diagnostics.length ? diagnostics : [];
   },


### PR DESCRIPTION
Linter doesn't trigger lint until the file has a valid path. So we can just ignore the check here.