### PR TITLE
Fixing install error notification to Atom UI

### DIFF
--- a/pkg/nuclide/installer-base/lib/main.js
+++ b/pkg/nuclide/installer-base/lib/main.js
@@ -123,8 +123,8 @@ async function installPackagesInConfig(config: InstallConfig): Promise<boolean> 
     // Write the error to the console to help the user debug the issue.
     console.error(failure); // eslint-disable-line no-console
 
-    atom.notifications.addSuccess(
-      `There was an error installing Nuclide packages:\n{failure.stack || failure}`);
+    atom.notifications.addError(
+      `There was an error installing Nuclide packages:\n${failure.stack || failure}`);
   } else {
     atom.notifications.addSuccess(
       `${numPackages} Nuclide package${numPackages === 1 ? '' : 's'} installed.`);


### PR DESCRIPTION
This fixes installation error message details not being displayed to user in Atom UI

![error](https://cloud.githubusercontent.com/assets/1795860/9876520/02d613ce-5bb7-11e5-8412-1b290148ebd7.png)