### PR TITLE
alt click doesn't work.

### DIFF
--- a/pkg/nuclide/hyperclick/lib/HyperclickForTextEditor.js
+++ b/pkg/nuclide/hyperclick/lib/HyperclickForTextEditor.js
@@ -10,7 +10,7 @@
  */
 
 import type Hyperclick from './Hyperclick';
-import {trackTiming, startTracking} from 'nuclide-analytics';a
+import {trackTiming, startTracking} from 'nuclide-analytics';
 import type {TimingTracker} from 'nuclide-analytics';
 
 var getWordTextAndRange = require('./get-word-text-and-range');

--- a/pkg/nuclide/hyperclick/lib/HyperclickForTextEditor.js
+++ b/pkg/nuclide/hyperclick/lib/HyperclickForTextEditor.js
@@ -10,7 +10,7 @@
  */
 
 import type Hyperclick from './Hyperclick';
-import {trackTiming, startTracking} from 'nuclide-analytics';
+import {trackTiming, startTracking} from 'nuclide-analytics';a
 import type {TimingTracker} from 'nuclide-analytics';
 
 var getWordTextAndRange = require('./get-word-text-and-range');
@@ -276,7 +276,7 @@ class HyperclickForTextEditor {
    */
   _isHyperclickEvent(event: SyntheticKeyboardEvent | SyntheticMouseEvent): boolean {
     // If the user is pressing either the meta key or the alt key.
-    return process.platform === 'darwin' ? event.metaKey : event.ctrlKey;
+    return process.platform === 'darwin' ? event.altKey : event.ctrlKey;
   }
 
   _isLoading(): boolean {


### PR DESCRIPTION
on OSx, alt click doesn't work now.
But on your readme.md, alt + click is supported.

cmd(meta) click is conflict with multi cursor click.

https://github.com/facebooknuclideapm/hyperclick/blob/master/README.md