### PR TITLE
Don't ignore lower pri suggestions in nuclide-hack autocomplete.

### DIFF
--- a/pkg/nuclide/hack/lib/main.js
+++ b/pkg/nuclide/hack/lib/main.js
@@ -58,7 +58,7 @@ module.exports = {
       selector: HACK_GRAMMARS.map(grammar => '.' + grammar).join(', '),
       inclusionPriority: 1,
       suggestionPriority: 3, // The context-sensitive hack autocompletions are more relevant than snippets.
-      excludeLowerPriority: true,
+      excludeLowerPriority: false,
 
       getSuggestions(
           request: {editor: TextEditor; bufferPosition: Point; scopeDescriptor: any; prefix: string}


### PR DESCRIPTION
This fixes https://github.com/facebook/nuclide/issues/254

I don't know why this option was originally set to true. Fixing this may introduce other issues. I'm happy to dig deeper if you have any pointers.