### PR TITLE
hyperclick : add right-label property to suggestion list

### DIFF
--- a/pkg/nuclide/hyperclick/README.md
+++ b/pkg/nuclide/hyperclick/README.md
@@ -95,6 +95,7 @@ The methods return a suggestion or a `Promise` that resolves to a suggestion:
   If there are multiple possibilities, this can be an array of objects with:
 
     - `title`: A string to present in the UI for the user to select.
+    - `rightLabel`(optional): An indicator denoting the "kind" of suggestion this represents
     - `callback`: The function to call when the user selects this object.
 
 Additional properties:

--- a/pkg/nuclide/hyperclick/lib/SuggestionListElement.js
+++ b/pkg/nuclide/hyperclick/lib/SuggestionListElement.js
@@ -123,7 +123,8 @@ class SuggestionList extends React.Component {
             key={index}
             onMouseDown={this._boundConfirm}
             onMouseEnter={this._setSelectedIndex.bind(this, index)}>
-          {item.title}
+            {item.title}
+            <span className="right-label">{item.rightLabel}</span>
         </li>
       );
     });

--- a/pkg/nuclide/hyperclick/styles/hyperclick.less
+++ b/pkg/nuclide/hyperclick/styles/hyperclick.less
@@ -29,3 +29,23 @@ hyperclick-suggestion-list {
 .hyperclick-result-item {
   cursor: pointer;
 }
+
+@font-size-small: .9em;
+@item-padding: .75em;
+@item-side-padding: .6em;
+
+hyperclick-suggestion-list {
+  .right-label {
+    float: right;
+    padding-left: @item-padding;
+    padding-right: @item-side-padding;
+
+    font-size: @font-size-small;
+    color: @text-color-subtle;
+
+    &:empty {
+      width: @item-side-padding;
+      padding: 0;
+    }
+  }
+}


### PR DESCRIPTION
Sometimes more information is needed in suggestion item.
(eg. destination file name, ...)
