### PR TITLE
Update setup instructinos for client/server for UP

### DIFF
--- a/_docs/remote.md
+++ b/_docs/remote.md
@@ -7,38 +7,41 @@ permalink: /docs/remote/
 
 ![Nuclide connecting to a remote server](/static/images/docs/NuclideRemote.gif)
 
-Nuclide includes a `nuclide-server` package which creates the bridge between
-your local client version of Nuclide, and the development server that you want
-to work on. It has its own setup process that is outlined below.
+Nuclide publishes the
+[`nuclide` NPM package](https://www.npmjs.com/package/nuclide), which creates
+the bridge between your local client version of Nuclide and the development
+machine on which you want to work. It has its own setup process that is outlined
+below.
 
 ## Nuclide Server Setup
 
-The following versions are required before installing the nuclide-server
-package:
+The following versions are required before installing the `nuclide` package:
 
 + Python 2.6 or later.
 + Node 0.12.0 or later.
 + `node`, and `npm` must be on your `$PATH`.
 + [Watchman](https://facebook.github.io/watchman). The Nuclide server
-requires Watchman to detect file and directory changes. You can build and/or
-install Watchman for your server's platform as described.
-[here](http://facebook.github.io/watchman/docs/install.html#build-install).
+requires Watchman to detect file and directory changes. Follow the Watchman
+[build or install instructions](http://facebook.github.io/watchman/docs/install.html#build-install)
+for your server's platform.
 + SSH Daemon - The Nuclide client connects to the server via SSH, so
 ensure that the server exposes an SSH daemon that you can connect to from your
-client machine, and that you know the credentials required - you will need to
+client machine, and that you know the credentials required. You will need to
 have an existing private key that can be used to connect to the server.
 + Port 9090-9093 exposed.  Note: you can specify another port in
-**Remote Server Command**. see "Connecting to your server from Nuclide" below.
+**Remote Server Command**. See
+["Connecting to your server from Nuclide"](#connecting-to-your-server-from-nuclide)
+below.
 
 ### Installing via NPM
 
-The easiest way to get nuclide-server is from NPM:
+The easiest way to get the Nuclide server is from NPM:
 
 ```bash
-npm install -g nuclide-server
+npm install -g nuclide
 ```
 
-We use the `-g` switch to ensure Nuclide is installed as a node global package.
+We use the `-g` switch to ensure Nuclide is installed as a Node global package.
 
 You do not need to explicitly start the server since the Nuclide client will
 attempt to do so when it first connects over SSH.
@@ -70,7 +73,7 @@ PATH=$PATH:$HOME/.npm_packages/bin; export PATH
 to the end of your .profile.  Now you should be able to run:
 
 ```bash
-npm install -g nuclide-server
+npm install -g nuclide
 ```
 
 without errors.
@@ -93,7 +96,7 @@ npm clear cache
 To connect to your server, go to the Packages menu in Atom and select the
 'Connect...' option.
 
-![Connect menu](/static/images/docs/connect_menu.png)
+![](/static/images/docs/connect_menu.png)
 
 You'll see the following dialog:
 
@@ -128,6 +131,6 @@ it is not yet running. The result will be that the root folder you just
 specified will appear in the left-hand tree view, underneath any local folders
 you might have had open:
 
-![Tree view](/static/images/docs/tree_remote.png)
+![](/static/images/docs/tree_remote.png)
 
 You can now use this tree to open and edit files as you would expect.

--- a/_docs/setup.md
+++ b/_docs/setup.md
@@ -9,20 +9,15 @@ permalink: /docs/setup/
 
 The easiest way to get Nuclide is to install it from Atom itself.
 In Atom, open the **Settings** pane and navigate to the **Install** tab.
-From there, you can search for the `nuclide-installer` package and click
+From there, you can search for the `nuclide` package and click
 the corresponding **Install** button in the search result to install it.
 
 Alternatively, if you are more comfortable using the command line,
 you can install it using `apm`:
 
 ```bash
-$ apm install nuclide-installer
+$ apm install nuclide
 ```
-
-The first time you start Atom after installing the `nuclide-installer` package, you will have to wait
-a few seconds for the installer to determine which Nuclide packages it needs to install or update.
-To determine whether the installer worked, go to the **Settings** pane in Atom and navigate to the **Packages**
-tab. From there, filter your installed packages by `nuclide-` and you should see quite a few results!
 
 ### Recommended Dependencies
 
@@ -67,5 +62,5 @@ may be a little slow because of the large number of Babel files that need to be 
 
 ## Installing Nuclide Server
 
-If you want to use Nuclide for remote development, you'll also need to setup the `nuclide-server`
+If you want to use Nuclide for remote development, you'll also need to setup the NPM `nuclide`
 package. Instructions can be found in the [Remote Development docs](/docs/remote/).


### PR DESCRIPTION
The Unified Package, v0.111.0, is a single Atom package. The server also
moved from 'nuclide-server' to 'nuclide'. Update the setup instructions
accordingly.