### PR TITLE
Fix ocamlmerlin config option

### DIFF
--- a/pkg/nuclide/ocaml-base/lib/MerlinProcess.js
+++ b/pkg/nuclide/ocaml-base/lib/MerlinProcess.js
@@ -239,7 +239,7 @@ export async function getInstance(file: NuclideUri): Promise<?MerlinProcess> {
  */
 function getPathToMerlin(): string {
   // $UPFixMe: This should use nuclide-features-config
-  return global.atom && global.atom.config.get('nuclide-ocaml.pathToMerlin') || 'ocamlmerlin';
+  return global.atom && global.atom.config.get('nuclide.nuclide-ocaml.pathToMerlin') || 'ocamlmerlin';
 }
 
 let isInstalledCache: ?boolean = null;


### PR DESCRIPTION
Most likely the leftover of the old nuclide setup? Plain
`'nuclide-ocaml.pathToMerlin'` isn't a thing unless you've explicitly
installed that package, which is deprecated afaik. This fixes the config
path.

There are other related places:

- pkg/nuclide/buck/base/lib/BuckProject.js:106
- pkg/nuclide/commons/lib/systemInfo.js:36

(New to Atom & Nuclide, not sure what the proper `nuclide-features-config ` should have been. But this is a quick fix).