### PR TITLE
Add --nodates option to "hg diff" invocation

### DIFF
--- a/pkg/nuclide/hg-repository-base/lib/HgServiceBase.js
+++ b/pkg/nuclide/hg-repository-base/lib/HgServiceBase.js
@@ -149,7 +149,8 @@ class HgServiceBase {
     // '--unified 0' gives us 0 lines of context around each change (we don't
     // care about the context).
     // '--noprefix' omits the a/ and b/ prefixes from filenames.
-    const args = ['diff', '--unified', '0', '--noprefix'].concat(filePaths);
+    // '--nodates' avoids appending dates to the file path line.
+    const args = ['diff', '--unified', '0', '--noprefix', '--nodates'].concat(filePaths);
     const options = {
       cwd: this.getWorkingDirectory(),
     };


### PR DESCRIPTION
I am running hg version 3.6.3 on Mac OS X 10.11.3 and trying to use it with nuclide 0.115.1 on Atom 1.5.0-beta3. The problem I am seeing is that the git diff package doesn't show gutter annotations when changes to files are made (after saving). Also the status bar isn't showing the +n -n information for changed files. 

After some debugging, it appears that the problem is due to the hg command including a date stamp in the header of diff messages.IIUC, the nuclide hg repository support runs the following command: (with HGPLAIN=1 in the environment) "hg diff --unified 0 --noprefix". The problem appears to be that this command produces a header like this:

diff -r b9e495e9a0d4 src/org/bitbucket/inkytonik/moama/tests/SyntaxAnalyserTests.scala
--- src/org/bitbucket/inkytonik/moama/tests/SyntaxAnalyserTests.scala	Thu Feb 04 09:14:17 2016 +1100
+++ src/org/bitbucket/inkytonik/moama/tests/SyntaxAnalyserTests.scala	Thu Feb 04 16:48:10 2016 +110

The hg repository code grabs the filename and date as one string which then becomes the key for cached information for the changes. Later when the nuclide hg code looks for cached information it just uses the filename (no date) so nothing is found.

Adding the --nodates option to the hg diff command removes the dates from the header and makes both the git diff gutter annotations and the status bar +n -n information work for me.