### PR TITLE
Increase hit target for header links

### DIFF
--- a/docs/_sass/_base.scss
+++ b/docs/_sass/_base.scss
@@ -763,12 +763,13 @@ a.blockButton {
         ul {
           margin: 0 -0.4em;
           li {
-            padding: 0 0.4em;
             display: inline-block;
 
             a {
+              padding: 14px 0.4em;
               border: 0;
               color: $nav-text;
+              display: inline-block;
 
               &:hover {
                 color: $header-text;

--- a/docs/_sass/_search.scss
+++ b/docs/_sass/_search.scss
@@ -42,7 +42,8 @@ input#algolia-doc-search {
   background: transparent url('/static/search.png') no-repeat left center;
   background-size: 16px 16px;
 
-  padding-left: 30px;
+  padding-left: 20px;
+  margin-left: 10px;
   font-size: 16px;
   line-height: 20px;
   background-color: $nav-bg;


### PR DESCRIPTION
We want the entire block to be clickable, not just the text itself

<img width="580" alt="screen shot 2016-03-07 at 2 49 59 pm" src="https://cloud.githubusercontent.com/assets/197597/13586182/5683acb6-e474-11e5-891a-846011986490.png">
