### PR TITLE
Increase hit target for left nav

### DIFF
--- a/docs/_sass/_base.scss
+++ b/docs/_sass/_base.scss
@@ -714,6 +714,7 @@ a.blockButton {
           margin-bottom: 0;
           padding-bottom: 0.2vh;
           padding-top: 0;
+          display: block;
         }
 
         .navToggle {


### PR DESCRIPTION
Before, you could only click by clicking on the exact text. I missed multiple times because of that, so went ahead and fixed it.

![](http://g.recordit.co/OXmU9m69pi.gif)
