### PR TITLE
Fixed broken link to OCaml

### DIFF
--- a/docs/_docs/editor/setup.md
+++ b/docs/_docs/editor/setup.md
@@ -124,7 +124,7 @@ Recommended packages include:
 
 - [`tool-bar`](https://atom.io/packages/tool-bar) to enable the [Nuclide toolbar](/docs/features/toolbar/).
 - [`sort-lines`](https://atom.io/packages/sort-lines) to enable sorting lines of text.
-- [`language-ocaml`](https://atom.io/packages/language-ocaml) to enable [OCaml](/docs/languages/ocaml/) language syntax highlighting.
+- [`language-ocaml`](https://atom.io/packages/language-ocaml) to enable [OCaml](/docs/languages/other/#ocaml) language syntax highlighting.
 - [`language-babel`](https://atom.io/packages/language-babel) to enable language grammar for [JS, Flow and React JS](/docs/languages/flow/), etc.
 - ...and [others](https://github.com/facebook/nuclide/blob/master/package.json) under `package-deps`.
 


### PR DESCRIPTION
The page `/docs/languages/ocaml` does not exist. There is however a section on OCaml on the `/docs/languages/other/`page.