### PR TITLE
[code-format] Switch between formatCode and formatEntireFile

### DIFF
--- a/pkg/nuclide-code-format/lib/CodeFormatManager.js
+++ b/pkg/nuclide-code-format/lib/CodeFormatManager.js
@@ -49,7 +49,8 @@ class CodeFormatManager {
     const selectionRange = editor.getSelectedBufferRange();
     const {start: selectionStart, end: selectionEnd} = selectionRange;
     let formatRange = null;
-    if (selectionStart.isEqual(selectionEnd)) {
+    const selectionRangeEmpty = selectionRange.isEmpty();
+    if (selectionRangeEmpty) {
       // If no selection is done, then, the whole file is wanted to be formatted.
       formatRange = buffer.getRange();
     } else {
@@ -62,7 +63,8 @@ class CodeFormatManager {
     }
 
     const provider = matchingProviders[0];
-    if (provider.formatCode != null) {
+    if (provider.formatCode != null &&
+      (!selectionRangeEmpty || provider.formatEntireFile == null)) {
       const codeReplacement = await provider.formatCode(editor, formatRange);
       // TODO(most): save cursor location.
       editor.setTextInBufferRange(formatRange, codeReplacement);

--- a/pkg/nuclide-code-format/lib/types.js
+++ b/pkg/nuclide-code-format/lib/types.js
@@ -11,8 +11,9 @@
 
 export type CodeFormatProvider = {
   /**
-   * Providers should implement exactly one of formatCode / formatEntireFile.
-   * formatCode should be preferred whenever possible.
+   * Providers should implement at least one of formatCode / formatEntireFile.
+   * If formatCode exists, it'll be used if the editor selection isn't empty, or
+   * if it's empty but formatEntireFile doesn't exist.
    */
 
   /**

--- a/pkg/nuclide-external-interfaces/1.0/atom.js
+++ b/pkg/nuclide-external-interfaces/1.0/atom.js
@@ -374,6 +374,7 @@ declare class atom$Range {
   constructor(pointA: RangeConstructorArg, pointB: RangeConstructorArg): void;
   start: atom$Point;
   end: atom$Point;
+  isEmpty(): boolean;
   isEqual(otherRange: atom$Range): boolean;
   containsPoint(point: atom$Point, exclusive?: boolean): boolean;
   serialize(): Array<Array<number>>;


### PR DESCRIPTION
This addresses the issue from
https://github.com/facebook/nuclide/commit/73b8c7346aa419bc4f05216ab578aeffb3f617a2#commitcomment-15965354
where we check for the presence of either formatCode or formatEntireFile
without taking into consideration whether there's a selected region.

The future logic for this should probably change, but this current
behaviour is _mostly_ backward-compatible.

Test plan:

Try it on a formatter that provides both options.

Small table (true = present):
Old:

| formatCode | formatEntireFile | result |
| ---------- | ---------------- | ------ |
| true | true | formatcode |
| true | false | formatcode |
| false | true | formatEntireFile |
| false | false | error |

New:

| formatCode | formatEntireFile | selectionEmpty | result |
| ---------- | ---------------- | -------------- | ------ |
| true | true | true | formatEntireFile (small behaviour change) |
| true | true | false | formatCode |
| true | false | true | formatCode |
| true | false | false | formatCode |
| false | true | x | formatEntireFile |
| false | false | x | error |




