### PR TITLE
Fix local projects on Windows.

### DIFF
--- a/pkg/nuclide-file-tree/lib/FileTreeContextMenu.js
+++ b/pkg/nuclide-file-tree/lib/FileTreeContextMenu.js
@@ -13,7 +13,7 @@ import {CompositeDisposable} from 'atom';
 import {EVENT_HANDLER_SELECTOR} from './FileTreeConstants';
 import FileTreeStore from './FileTreeStore';
 
-import {isFullyQualifiedLocalPath} from './FileTreeHelpers';
+import path from 'path';
 
 type MenuItemSingle = {
   label: string;
@@ -196,7 +196,7 @@ class FileTreeContextMenu {
     const node = this._store.getSingleSelectedNode();
     return (
       node != null &&
-      isFullyQualifiedLocalPath(node.nodePath) &&
+      path.isAbsolute(node.nodePath) &&
       process.platform === platform
     );
   }

--- a/pkg/nuclide-file-tree/lib/FileTreeHelpers.js
+++ b/pkg/nuclide-file-tree/lib/FileTreeHelpers.js
@@ -139,17 +139,13 @@ function getDisplayTitle(key: string): ?string {
 function isValidDirectory(directory: Directory): boolean {
   return (
     !isLocalEntry((directory: any)) ||
-    isFullyQualifiedLocalPath(directory.getPath())
+    pathModule.isAbsolute(directory.getPath())
   );
 }
 
 function isLocalEntry(entry: Entry): boolean {
   // TODO: implement `RemoteDirectory.isRemoteDirectory()`
   return !('getLocalPath' in entry);
-}
-
-function isFullyQualifiedLocalPath(path: string): boolean {
-  return path.charAt(0) === pathModule.sep;
 }
 
 function isContextClick(event: SyntheticMouseEvent): boolean {
@@ -176,7 +172,6 @@ module.exports = {
   getDisplayTitle,
   isValidDirectory,
   isLocalEntry,
-  isFullyQualifiedLocalPath,
   isContextClick,
   buildHashKey,
 };

--- a/pkg/nuclide-file-tree/spec/FileTreeHelpers-spec.js
+++ b/pkg/nuclide-file-tree/spec/FileTreeHelpers-spec.js
@@ -75,17 +75,16 @@ describe('FileTreeHelpers', () => {
   });
 
   describe('on Windows', () => {
-    let originalPathSep;
+    let originalPathModule;
 
     beforeEach(() => {
-      // `require('path').sep` denotes the path separator for the current platform. Set it to a
-      // backslash ('\\') to mimic running on Windows.
-      originalPathSep = pathModule.sep;
-      pathModule.sep = pathModule.win32.sep;
+      // Clone path module, then override all functions with the Windows version
+      originalPathModule = Object.assign({}, pathModule);
+      Object.assign(pathModule, pathModule.win32);
     });
 
     afterEach(() => {
-      pathModule.sep = originalPathSep;
+      Object.assign(pathModule, originalPathModule);
     });
 
     it('should convert key to path', () => {
@@ -110,9 +109,9 @@ describe('FileTreeHelpers', () => {
     });
 
     it('should determine if a key represents a directory', () => {
-      expect(FileTreeHelpers.isDirKey('\\a\\b\\foo')).toBe(false);
-      expect(FileTreeHelpers.isDirKey('\\a\\b\\')).toBe(true);
-      expect(FileTreeHelpers.isDirKey('\\a\\b\\\\')).toBe(true);
+      expect(FileTreeHelpers.isDirKey('c:\\a\\b\\foo')).toBe(false);
+      expect(FileTreeHelpers.isDirKey('c:\\a\\b\\')).toBe(true);
+      expect(FileTreeHelpers.isDirKey('c:\\a\\b\\\\')).toBe(true);
       expect(FileTreeHelpers.isDirKey('nuclide://host:456\\a\\b')).toBe(false);
       expect(FileTreeHelpers.isDirKey('nuclide://host:456\\a\\b\\')).toBe(true);
     });
@@ -122,7 +121,7 @@ describe('FileTreeHelpers', () => {
     });
 
     it('should validate directories', () => {
-      const validDir = new Directory('\\a\\b\\c');
+      const validDir = new Directory('c:\\a\\b\\c');
       expect(FileTreeHelpers.isValidDirectory(validDir)).toBe(true);
       const badDir = new Directory('nuclide://host:123\\a\\b\\c');
       expect(FileTreeHelpers.isValidDirectory(badDir)).toBe(false);


### PR DESCRIPTION
Nuclide should use [path.isAbsolute](https://nodejs.org/api/path.html#path_path_isabsolute_path) to determine if a local file path is absolute rather than checking if `path.indexOf(0) === separator`, as that approach doesn't work on Windows.

Closes #375

<img src="http://ss.dan.cx/2016/03/atom_28-21.32.37.png" />