### PR TITLE
Temporary hack to fix "Reveal in File Tree" freezing on Windows

### DIFF
--- a/pkg/nuclide-file-tree/lib/FileTreeHelpers.js
+++ b/pkg/nuclide-file-tree/lib/FileTreeHelpers.js
@@ -57,6 +57,15 @@ function getParentKey(key: string): string {
   const parsed = RemoteUri.parse(path);
   parsed.pathname = pathModule.join(parsed.pathname, '..');
   const parentPath = url.format((parsed: any));
+
+  // Temporary hack for remote editing on Windows. Currently the above path
+  // handling code conflates paths and URIs, which results in some weirdness in
+  // the resulting string on systems where URI separator differs from path
+  // separator.
+  if (process.platform === 'win32') {
+    parentPath = parentPath.replace('/\\', '\\');
+  }
+
   return dirPathToKey(parentPath);
 }
 


### PR DESCRIPTION
Some of the path handling code conflates local file system path handling (using the `path` module, where `path.sep` is the separator) with URI handling (using the `uri` module, where `/` is the separator). This works (but is technically incorrect) on POSIX systems where the local file system uses the same `/` separator as URIs, but it fails on Windows where the separator differs.

One example of a problem case is `getParentKey` in `FileTreeHelpers`, which uses `path.join` followed by `url.format` to manipulate the value. On Linux, this works fine:
```
> path.join('/home/daniel/foo/bar', '..')
'/home/daniel/foo'
> url.format({hostname: 'dev', pathname: path.join('/home/daniel/foo/bar', '..'), port: 8084, protocol: 'nuclide:', slashes: true})
'nuclide://dev:8084/home/daniel/foo'
```

However, on Windows, the slashes get messed up:
```
> path.join('/home/daniel/foo/bar', '..')
'\\home\\daniel\\foo'
> url.format({hostname: 'dev', pathname: path.join('/home/daniel/foo/bar', '..'), port: 8084, protocol: 'nuclide:', slashes: true})
'nuclide://dev:8084/\\home\\daniel\\foo'
```

Notice how `path.join` uses `\` rather than `/`. This is correct, as the **local file system** uses `\` as the separator. However, this is **not correct** for a URI, which should always be using `/`.

Even with this issue, paths are *mostly* working in Nuclide on Windows. The only major issue I've seen is that most of the code has the path in the format `nuclide://dev:8084\home\daniel\foo`, whereas `url.format` returns it in the format `nuclide://dev:8084/\home\daniel\foo`. Notice the extra slash `/\` at the very beginning of the path. This results in `while (currentParentUri !== deepest.uri) {` getting stuck in an infinite loop, as the "current" URI (with the extra slash) will **never** match the "deepest" URI (without the extra slash).

Hence this pull request. This is super super hacky, but it fixes my current pain point. This path handling code really needs to be refactored to not conflate the two types of paths - Functions that use both **path** and **uri** are a bad sign that something will break when the two don't overlap.