### PR TITLE
Keymap to create new file with tree view path

### DIFF
--- a/pkg/nuclide-file-tree/keymaps/nuclide-file-tree.json
+++ b/pkg/nuclide-file-tree/keymaps/nuclide-file-tree.json
@@ -100,12 +100,14 @@
     "cmd-k right": "nuclide-file-tree:open-selected-entry-right",
     "cmd-k left": "nuclide-file-tree:open-selected-entry-left",
     "cmd-k up": "nuclide-file-tree:open-selected-entry-up",
-    "cmd-k down": "nuclide-file-tree:open-selected-entry-down"
+    "cmd-k down": "nuclide-file-tree:open-selected-entry-down",
+    "cmd-n": "nuclide-file-tree:add-file"
   },
   ".platform-win32 .nuclide-file-tree, .platform-linux .nuclide-file-tree": {
     "ctrl-k right": "nuclide-file-tree:open-selected-entry-right",
     "ctrl-k left": "nuclide-file-tree:open-selected-entry-left",
     "ctrl-k up": "nuclide-file-tree:open-selected-entry-up",
-    "ctrl-k down": "nuclide-file-tree:open-selected-entry-down"
+    "ctrl-k down": "nuclide-file-tree:open-selected-entry-down",
+    "ctrl-n": "nuclide-file-tree:add-file"
   }
 }


### PR DESCRIPTION
I always try not to use the mouse when i'm coding and right now if I need create a new file I must use mouse right click `new -> file` option.

The attempt of this pull request is allow file creation only with the keyboard for example `ctrl-0` and `cmd+n`