### PR TITLE
Make header bar participate in stacking context

### DIFF
--- a/docs/_sass/_base.scss
+++ b/docs/_sass/_base.scss
@@ -51,6 +51,7 @@ h1, h2, h3, h4 {
   height: $header-height;
   opacity: 0.0;
   padding: $header-ptop 0 $header-pbot;
+  position: relative;
   -webkit-transition: opacity 0.2s ease-in-out;
   transition: opacity 0.2s ease-in-out;
   width: 100%;

--- a/docs/_sass/_base.scss
+++ b/docs/_sass/_base.scss
@@ -44,7 +44,6 @@ h1, h2, h3, h4 {
   font-family: $header-font-family;
 }
 
-// static positioning, by default.
 .headerBarContainer {
   background: $primary-bg;
   color: $header-text;


### PR DESCRIPTION
This commit fixes a z-index issue on [http://nuclide.io](http://nuclide.io) as viewed on small screens.

Currently, the .headerBarContainer has a z-index of 9999, but when styled as a hamburger menu, it does not meet [the criteria](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context) to create a stacking context.

As a result, the z-index doesn't have the expected effect: .promoSection is rendered above the opened hamburger menu:

<img width="396" alt="screen shot 2016-05-15 at 9 06 58 pm" src="https://cloud.githubusercontent.com/assets/6564473/15278065/11e81242-1ae1-11e6-990c-711d1b60c9d0.png">

The simplest fix is to position the element.
