### PR TITLE
Fix issue: empty string -> no valid JSON error

### DIFF
--- a/pkg/nuclide-flow-base/lib/FlowRoot.js
+++ b/pkg/nuclide-flow-base/lib/FlowRoot.js
@@ -331,7 +331,7 @@ export class FlowRoot {
 
 function parseJSON(args: Array<any>, value: string): any {
   try {
-    return JSON.parse(value);
+    return value ? JSON.parse(value) : {};;
   } catch (e) {
     logger.error(`Invalid JSON result from flow ${args.join(' ')}. JSON:\n'${value}'.`);
     throw e;

--- a/pkg/nuclide-flow-base/lib/FlowRoot.js
+++ b/pkg/nuclide-flow-base/lib/FlowRoot.js
@@ -331,7 +331,7 @@ export class FlowRoot {
 
 function parseJSON(args: Array<any>, value: string): any {
   try {
-    return value ? JSON.parse(value) : {};;
+    return value ? JSON.parse(value) : {};
   } catch (e) {
     logger.error(`Invalid JSON result from flow ${args.join(' ')}. JSON:\n'${value}'.`);
     throw e;


### PR DESCRIPTION
This change will fix meaningless error:
```shell
[ERROR] nuclide - Invalid JSON result from flow status --json /Users/frogcjn/Files/Projects/Node.js-Projects/shoutbox-babel/src/index.js. JSON:
```
when value is an empty string.