### PR TITLE
Tell flow to ignore missing facebook modules

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -21,6 +21,8 @@
 suppress_comment=.*\\$FlowFixMe.*
 suppress_comment=.*\\$FlowIssue.*
 suppress_comment=.*\\$FlowIgnore.*
+# uncommenting the next line will silence flow errors about missing 'fb' modules
+# suppress_comment=.*\\$FlowFB.*
 
 esproposal.class_static_fields=enable
 esproposal.decorators=ignore

--- a/pkg/commons-node/passesGK.js
+++ b/pkg/commons-node/passesGK.js
@@ -22,6 +22,7 @@ export default async function passesGK(
   // Only do the expensive require once.
   if (gatekeeper === undefined) {
     try {
+      // $FlowFB
       gatekeeper = require('../fb-gatekeeper').gatekeeper;
     } catch (e) {
       gatekeeper = null;

--- a/pkg/hyperclick/lib/main.js
+++ b/pkg/hyperclick/lib/main.js
@@ -23,6 +23,7 @@ export function activate() {
   // with the Hyperclick "confirm-cursor" command.
   // TODO(hansonw): Remove when symbols-view has a proper API.
   try {
+    // $FlowFB
     const {overrideGoToDeclaration} = require('./fb/overrideGoToDeclaration');
     overrideGoToDeclaration();
   } catch (e) {

--- a/pkg/nuclide-analytics/lib/track.js
+++ b/pkg/nuclide-analytics/lib/track.js
@@ -17,6 +17,7 @@ export type TrackEvent = {
 // This extra module enables adding spies during testing.
 export let track;
 try {
+  // $FlowFB
   track = require('../fb/analytics').track;
 } catch (e) {
   track = require('./analytics').track;

--- a/pkg/nuclide-blame-provider-hg/lib/HgBlameProvider.js
+++ b/pkg/nuclide-blame-provider-hg/lib/HgBlameProvider.js
@@ -104,6 +104,7 @@ function identity<T>(anything: T): T {
 
 let getUrlForRevision;
 try {
+  // $FlowFB
   const {getPhabricatorUrlForRevision} = require('./fb/FbHgBlameProvider');
   getUrlForRevision = getPhabricatorUrlForRevision;
 } catch (e) {

--- a/pkg/nuclide-clang/lib/ClangFlagsManager.js
+++ b/pkg/nuclide-clang/lib/ClangFlagsManager.js
@@ -60,6 +60,7 @@ function overrideIncludePath(src: string): string {
   if (_overrideIncludePath === undefined) {
     _overrideIncludePath = null;
     try {
+      // $FlowFB
       _overrideIncludePath = require('./fb/custom-flags').overrideIncludePath;
     } catch (e) {
       // open-source version

--- a/pkg/nuclide-clang/lib/ClangServer.js
+++ b/pkg/nuclide-clang/lib/ClangServer.js
@@ -32,6 +32,7 @@ async function augmentDefaultFlags(src: string, flags: Array<string>): Promise<A
   if (getDefaultFlags === undefined) {
     getDefaultFlags = null;
     try {
+      // $FlowFB
       getDefaultFlags = require('./fb/custom-flags').getDefaultFlags;
     } catch (e) {
       // Open-source version

--- a/pkg/nuclide-clang/lib/find-clang-server-args.js
+++ b/pkg/nuclide-clang/lib/find-clang-server-args.js
@@ -23,6 +23,7 @@ export default async function findClangServerArgs(): Promise<{
   if (fbFindClangServerArgs === undefined) {
     fbFindClangServerArgs = null;
     try {
+      // $FlowFB
       fbFindClangServerArgs = require('./fb/find-clang-server-args');
     } catch (e) {
       // Ignore.

--- a/pkg/nuclide-debugger-hhvm/lib/AttachProcessInfo.js
+++ b/pkg/nuclide-debugger-hhvm/lib/AttachProcessInfo.js
@@ -22,6 +22,7 @@ export class AttachProcessInfo extends DebuggerProcessInfo {
 
   async debug(): Promise<HhvmDebuggerInstance> {
     try {
+      // $FlowFB
       const services = require('./fb/services');
       await services.warnIfNotBuilt(this.getTargetUri());
     } catch (_) {}

--- a/pkg/nuclide-flow/lib/FlowServiceWatcher.js
+++ b/pkg/nuclide-flow/lib/FlowServiceWatcher.js
@@ -65,6 +65,7 @@ async function handleFailure(pathToRoot: NuclideUri): Promise<void> {
     text: 'Restart Flow Server',
   }];
   try {
+    // $FlowFB
     const reportButton = await require('./fb-report-crash').getButton();
     if (reportButton != null) {
       buttons.push(reportButton);

--- a/pkg/nuclide-hg-repository-base/lib/HgService.js
+++ b/pkg/nuclide-hg-repository-base/lib/HgService.js
@@ -161,6 +161,7 @@ async function getForkBaseName(directoryPath: string): Promise<string> {
 function getPrimaryWatchmanSubscriptionRefinements(): Array<mixed> {
   let refinements = [];
   try {
+    // $FlowFB
     refinements = require('./fb/config').primaryWatchSubscriptionRefinements;
   } catch (e) {
     // purposely blank

--- a/pkg/nuclide-notifications/lib/main.js
+++ b/pkg/nuclide-notifications/lib/main.js
@@ -31,6 +31,7 @@ export function activate(state: ?Object): void {
 
   try {
     // Listen for the gatekeeper to tell us if we can generate native notifications.
+    // $FlowFB
     const gatekeeper = require('../../fb-gatekeeper').gatekeeper;
     subscriptions.add(
       gatekeeper.onceInitialized(() => {

--- a/pkg/nuclide-python-base/lib/JediService.js
+++ b/pkg/nuclide-python-base/lib/JediService.js
@@ -61,6 +61,7 @@ async function getPythonPath() {
   pythonPath = 'python';
   try {
     // Override the python path if override script is present.
+    // $FlowFB
     const overrides = await require('./fb/find-jedi-server-args')();
     if (overrides.pythonExecutable) {
       pythonPath = overrides.pythonExecutable;

--- a/pkg/nuclide-remote-projects/lib/connection-profile-utils.js
+++ b/pkg/nuclide-remote-projects/lib/connection-profile-utils.js
@@ -147,6 +147,7 @@ export function getDefaultConfig(): any {
   }
   let defaultConfigGetter;
   try {
+    // $FlowFB
     defaultConfigGetter = require('./fb/config');
   } catch (e) {
     defaultConfigGetter = require('./config');

--- a/pkg/nuclide-server/lib/main.js
+++ b/pkg/nuclide-server/lib/main.js
@@ -27,6 +27,7 @@ export type AgentOptions = {
 
 function setupServer(): void {
   try {
+    // $FlowFB
     require('./fb/setup').setupServer();
   } catch (e) {
     // Swallow the error while runing in open sourced version.

--- a/pkg/nuclide-server/lib/services.js
+++ b/pkg/nuclide-server/lib/services.js
@@ -21,6 +21,7 @@ export function loadServicesConfig(): Array<ConfigEntry> {
   const publicServices = createServiceConfigObject(require('../services-3.json'));
   let privateServices = [];
   try {
+    // $FlowFB
     privateServices = createServiceConfigObject(require('../fb/fb-services-3.json'));
   } catch (e) {
     // This file may not exist.


### PR DESCRIPTION
This PR tells `flow` not to report errors for the various places where `fb` modules are required but may not be available. I'm assuming these are modules for internal use at facebook since they are not installed with the other dependencies and, as far as I could tell, not mentioned in the documentation.