### PR TITLE
reorder comparison operators to maximize ligature coverage

### DIFF
--- a/pkg/nuclide-language-hack/grammars/hack.cson
+++ b/pkg/nuclide-language-hack/grammars/hack.cson
@@ -1181,6 +1181,10 @@
         'name': 'keyword.operator.error-control.php'
       }
       {
+        'match': '(!==|!=|===|==|<=|>=|<>|<|>)'
+        'name': 'keyword.operator.comparison.php'
+      }
+      {
         'match': '=|\\+=|\\-=|\\*=|/=|%=|&=|\\|=|\\^=|<<=|>>='
         'name': 'keyword.operator.assignment.php'
       }
@@ -1202,10 +1206,6 @@
       {
         'match': '<<|>>|~|\\^|&|\\|'
         'name': 'keyword.operator.bitwise.php'
-      }
-      {
-        'match': '(===|==|!==|!=|<=|>=|<>|<|>)'
-        'name': 'keyword.operator.comparison.php'
       }
       {
         'begin': '(?i)\\b(instanceof)\\b\\s+(?=[\\\\$a-z_])'


### PR DESCRIPTION
In the original, the = match from keyword.operator.assignment.php will fire before !=, ===, etc. can be matched by keyword.operator.comparison.php.  This splits the comparison operator into two styled spans, which breaks ligature replacement in code-oriented fonts.  This diff reorders more specific matches for keyword.operator.comparison.php ahead of the less specific ones for keyword.operator.assignment.php.