### PR TITLE
grammar change

### DIFF
--- a/docs/_docs/editor/setup.md
+++ b/docs/_docs/editor/setup.md
@@ -54,7 +54,7 @@ Installing Nuclide is a one-line command at the command-line:
 $ apm install nuclide
 ```
 
-Or you can go through the Atom Packages UI to install Atom:
+or you can go through the Atom Packages UI:
 
 1. Open Atom.
 2. Choose `Atom | Preferences` to bring up the `Settings` pane. (on Linux this will be


### PR DESCRIPTION
Was reading the docs and this part was bugging me.

Removed the line `to install Atom` which should've read `to install Nuclide` and changed to a lower case `o` to match the uniformity of other sentences preceding this in the docs.