### PR TITLE
Fix for 'flow' path check on Windows

### DIFF
--- a/pkg/nuclide-flow-base/lib/FlowHelpers.js
+++ b/pkg/nuclide-flow-base/lib/FlowHelpers.js
@@ -133,9 +133,16 @@ async function isFlowInstalled(): Promise<boolean> {
   return flowPathCache.get(flowPath);
 }
 
+
+
 async function canFindFlow(flowPath: string): Promise<boolean> {
+  // fix for locating flow on Windows
+  // https://github.com/facebook/nuclide/issues/561
+  const locatorTool = (process.platform === 'win32') ?
+    'where' :
+    'which';
   try {
-    await checkOutput('which', [flowPath]);
+    await checkOutput(locatorTool, [flowPath]);
     return true;
   } catch (e) {
     return false;


### PR DESCRIPTION
Fix for https://github.com/facebook/nuclide/issues/561. 

If OS is Windows use `where` insdead of `which`