### PR TITLE
Adds dragged file path to emited event

### DIFF
--- a/pkg/nuclide-file-tree/components/FileTreeEntryComponent.js
+++ b/pkg/nuclide-file-tree/components/FileTreeEntryComponent.js
@@ -284,7 +284,7 @@ export class FileTreeEntryComponent extends React.Component {
     const nativeEvent = (event.nativeEvent: any);
     nativeEvent.dataTransfer.effectAllowed = 'move';
     nativeEvent.dataTransfer.setDragImage(fileIcon, -8, -4);
-    nativeEvent.dataTransfer.setData("initialPath", this.props.node.uri);
+    nativeEvent.dataTransfer.setData('initialPath', this.props.node.uri);
     window.requestAnimationFrame(() => document.body.removeChild(fileIcon));
   }
 

--- a/pkg/nuclide-file-tree/components/FileTreeEntryComponent.js
+++ b/pkg/nuclide-file-tree/components/FileTreeEntryComponent.js
@@ -284,7 +284,7 @@ export class FileTreeEntryComponent extends React.Component {
     const nativeEvent = (event.nativeEvent: any);
     nativeEvent.dataTransfer.effectAllowed = 'move';
     nativeEvent.dataTransfer.setDragImage(fileIcon, -8, -4);
-
+    nativeEvent.dataTransfer.setData("initialPath", this.props.node.uri);
     window.requestAnimationFrame(() => document.body.removeChild(fileIcon));
   }
 


### PR DESCRIPTION
Hi,

This PR adds file path to DragEvent of FileTreeItems, to let plugins developers create features based on file dragged from filetree and dropped in others panes. Atom file tree already set initialPath so I've only added the same line to keep a similar API to bind with.

Thank you