### PR TITLE
Hyperclick uses ctrl-key instead of alt-key on Windows

### DIFF
--- a/pkg/hyperclick/lib/HyperclickForTextEditor.js
+++ b/pkg/hyperclick/lib/HyperclickForTextEditor.js
@@ -332,7 +332,7 @@ export default class HyperclickForTextEditor {
    */
   _isHyperclickEvent(event: SyntheticKeyboardEvent | MouseEvent): boolean {
     // If the user is pressing either the meta/ctrl key or the alt key.
-    return process.platform === 'darwin' ? event.metaKey : event.ctrlKey;
+    return process.platform === 'darwin' ? event.metaKey : event.altKey;
   }
 
   _doneLoading(): void {


### PR DESCRIPTION
It seems the Hyperclick package uses the ctrl-key instead of the described alt-key on Windows. Using the ctrl-key is a problem in Atom, because it is used for making multiple text/cursor selections. This PR changes the ctrl-key to alt-key.