### PR TITLE
Restrict max workers to something sane

### DIFF
--- a/pkg/nuclide-flow-base/lib/FlowProcess.js
+++ b/pkg/nuclide-flow-base/lib/FlowProcess.js
@@ -310,7 +310,7 @@ export class FlowProcess {
   }
 
   _getMaxWorkers(): number {
-    return Math.max(os.cpus().length - 2, 1);
+    return Math.ceil(os.cpus().length / 4);
   }
 
   /**


### PR DESCRIPTION
When the number of CPUs on a machine is quite large, flow spawns enough processes to saturate IO and starve everything else on the machine. This change makes it so that on machines with a very large number of cores, flow plays more nicely with other things (arc, hh, etc) happening concurrently. This is especially impactful when you do a rebase that touches a lot of files, and try to run a lot of unit tests or something shortly after.

See https://www.desmos.com/calculator/or5ppybxia for a graph of current versus new algos for max workers.