### PR TITLE
Which returns first result

### DIFF
--- a/pkg/commons-node/spec/which-spec.js
+++ b/pkg/commons-node/spec/which-spec.js
@@ -1,15 +1,24 @@
 'use babel';
 /* @flow */
 
+/*
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ */
+
 import which from '../which';
 
 describe('which', () => {
   let checkOutput: JasmineSpy;
-  let checkOutputReturn = {stdout: ''};
+  let checkOutputReturn: Object = null;
 
   beforeEach(() => {
+    checkOutputReturn = {stdout: ''};
     checkOutput = spyOn(require('../process'), 'checkOutput').andCallFake(() =>
-      checkOutputReturn
+      checkOutputReturn,
     );
   });
 
@@ -20,7 +29,7 @@ describe('which', () => {
   describe('on windows', () => {
     const real_platform: string = process.platform;
     const eol = '\r\n';
-    let os = require('os');
+    const os = require('os');
     const real_eol = os.EOL;
     beforeEach(() => {
       Object.defineProperty(process, 'platform', {value: 'win32'});
@@ -32,7 +41,7 @@ describe('which', () => {
     });
 
     it('calls where on Windows', () => {
-      let param: string = '';
+      const param: string = '';
       which(param);
       expect(checkOutput).toHaveBeenCalledWith('where', [param]);
     });
@@ -49,7 +58,7 @@ describe('which', () => {
   describe('on linux', () => {
     const real_platform: string = process.platform;
     const eol = '\n';
-    let os = require('os');
+    const os = require('os');
     const real_eol = os.EOL;
     beforeEach(() => {
       Object.defineProperty(process, 'platform', {value: 'linux'});
@@ -61,7 +70,7 @@ describe('which', () => {
     });
 
     it('calls which', () => {
-      let param: string = '';
+      const param: string = '';
       which(param);
       expect(checkOutput).toHaveBeenCalledWith('which', [param]);
     });

--- a/pkg/commons-node/spec/which-spec.js
+++ b/pkg/commons-node/spec/which-spec.js
@@ -13,7 +13,7 @@ import which from '../which';
 
 describe('which', () => {
   let checkOutput: JasmineSpy;
-  let checkOutputReturn: Object = null;
+  let checkOutputReturn: {stdout: string} = (null: any);
 
   beforeEach(() => {
     checkOutputReturn = {stdout: ''};

--- a/pkg/commons-node/spec/which-spec.js
+++ b/pkg/commons-node/spec/which-spec.js
@@ -4,6 +4,19 @@
 import which from '../which';
 
 describe('which', () => {
+  let checkOutput: JasmineSpy;
+  let checkOutputReturn = {stdout: ''};
+
+  beforeEach(() => {
+    checkOutput = spyOn(require('../process'), 'checkOutput').andCallFake(() =>
+      checkOutputReturn
+    );
+  });
+
+  afterEach(() => {
+    jasmine.unspy(require('../process'), 'checkOutput');
+  });
+
   describe('on windows', () => {
     const real_platform: string = process.platform;
     const eol = '\r\n';
@@ -19,7 +32,6 @@ describe('which', () => {
     });
 
     it('calls where on Windows', () => {
-      let checkOutput: JasmineSpy = spyOn(require('../process'), 'checkOutput').andReturn('hello');
       let param: string = '';
       which(param);
       expect(checkOutput).toHaveBeenCalledWith('where', [param]);
@@ -27,8 +39,7 @@ describe('which', () => {
 
     it('returns the first match', () => {
       waitsForPromise(async () => {
-        let returnValue = {stdout: 'hello' + os.EOL + 'hello.exe' + os.EOL};
-        let checkOutput: JasmineSpy = spyOn(require('../process'), 'checkOutput').andReturn(returnValue);
+        checkOutputReturn.stdout = 'hello' + os.EOL + 'hello.exe' + os.EOL;
         const ret = await which('bla');
         expect(ret).toEqual('hello');
       });
@@ -50,7 +61,6 @@ describe('which', () => {
     });
 
     it('calls which', () => {
-      let checkOutput: JasmineSpy = spyOn(require('../process'), 'checkOutput').andReturn('hello');
       let param: string = '';
       which(param);
       expect(checkOutput).toHaveBeenCalledWith('which', [param]);
@@ -58,8 +68,7 @@ describe('which', () => {
 
     it('returns the first match', () => {
       waitsForPromise(async () => {
-        let returnValue = {stdout: 'hello' + os.EOL + '/bin/hello' + os.EOL};
-        let checkOutput: JasmineSpy = spyOn(require('../process'), 'checkOutput').andReturn(returnValue);
+        checkOutputReturn.stdout = 'hello' + os.EOL + '/bin/hello' + os.EOL;
         const ret = await which('bla');
         expect(ret).toEqual('hello');
       });

--- a/pkg/commons-node/spec/which-spec.js
+++ b/pkg/commons-node/spec/which-spec.js
@@ -1,0 +1,68 @@
+'use babel';
+/* @flow */
+
+import which from '../which';
+
+describe('which', () => {
+  describe('on windows', () => {
+    const real_platform: string = process.platform;
+    const eol = '\r\n';
+    let os = require('os');
+    const real_eol = os.EOL;
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', {value: 'win32'});
+      os.EOL = eol;
+    });
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', {value: real_platform});
+      os.EOL = real_eol;
+    });
+
+    it('calls where on Windows', () => {
+      let checkOutput: JasmineSpy = spyOn(require('../process'), 'checkOutput').andReturn('hello');
+      let param: string = '';
+      which(param);
+      expect(checkOutput).toHaveBeenCalledWith('where', [param]);
+    });
+
+    it('returns the first match', () => {
+      waitsForPromise(async () => {
+        let returnValue = {stdout: 'hello' + os.EOL + 'hello.exe' + os.EOL};
+        let checkOutput: JasmineSpy = spyOn(require('../process'), 'checkOutput').andReturn(returnValue);
+        const ret = await which('bla');
+        expect(ret).toEqual('hello');
+      });
+    });
+  });
+
+  describe('on linux', () => {
+    const real_platform: string = process.platform;
+    const eol = '\n';
+    let os = require('os');
+    const real_eol = os.EOL;
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', {value: 'linux'});
+      os.EOL = eol;
+    });
+    afterEach(() => {
+      Object.defineProperty(process, 'platform', {value: real_platform});
+      os.EOL = real_eol;
+    });
+
+    it('calls which', () => {
+      let checkOutput: JasmineSpy = spyOn(require('../process'), 'checkOutput').andReturn('hello');
+      let param: string = '';
+      which(param);
+      expect(checkOutput).toHaveBeenCalledWith('which', [param]);
+    });
+
+    it('returns the first match', () => {
+      waitsForPromise(async () => {
+        let returnValue = {stdout: 'hello' + os.EOL + '/bin/hello' + os.EOL};
+        let checkOutput: JasmineSpy = spyOn(require('../process'), 'checkOutput').andReturn(returnValue);
+        const ret = await which('bla');
+        expect(ret).toEqual('hello');
+      });
+    });
+  });
+});

--- a/pkg/commons-node/which.js
+++ b/pkg/commons-node/which.js
@@ -10,7 +10,7 @@
  */
 
 import {checkOutput} from './process';
-import {EOL} from 'os';
+import os from 'os';
 
 /**
  * Provides a cross-platform way to check whether a binary is available.
@@ -22,7 +22,7 @@ export default async function which(command: string): Promise<?string> {
   const whichCommand = process.platform === 'win32' ? 'where' : 'which';
   try {
     const result = await checkOutput(whichCommand, [command]);
-    return result.stdout.split(EOL)[0];
+    return result.stdout.split(os.EOL)[0];
   } catch (e) {
     return null;
   }

--- a/pkg/commons-node/which.js
+++ b/pkg/commons-node/which.js
@@ -10,6 +10,7 @@
  */
 
 import {checkOutput} from './process';
+import {EOL} from 'os';
 
 /**
  * Provides a cross-platform way to check whether a binary is available.
@@ -21,7 +22,7 @@ export default async function which(command: string): Promise<?string> {
   const whichCommand = process.platform === 'win32' ? 'where' : 'which';
   try {
     const result = await checkOutput(whichCommand, [command]);
-    return result.stdout.trim();
+    return result.stdout.split(EOL)[0];
   } catch (e) {
     return null;
   }


### PR DESCRIPTION
This fixes a problem on windows where `where.exe` can return multiple lines if the command is found multiple times on the `PATH`. This is especially painful since the recommended `npm install -g flow-bin` creates two `flow` binaries on by default so the entire flow support is broken, as mentioned in #321.

Also added tests. 