### PR TITLE
Save form in Remote Connection Profile Builder when enter key is pressed

### DIFF
--- a/pkg/nuclide-remote-projects/lib/CreateConnectionProfileForm.js
+++ b/pkg/nuclide-remote-projects/lib/CreateConnectionProfileForm.js
@@ -107,7 +107,7 @@ class CreateConnectionProfileForm extends React.Component<void, Props, void> {
           initialAuthMethod={initialFields.authMethod}
           initialDisplayTitle={initialFields.displayTitle}
           onCancel={emptyFunction}
-          onConfirm={emptyFunction}
+          onConfirm={this._clickSave}
           onDidChange={emptyFunction}
           ref="connection-details"
         />


### PR DESCRIPTION
When the Remote Connection profile building dialog, hitting 'enter' with the password input box focussed will not perform the "Save" action -- however, doing so in any other input box inside this form will.

This is because all the other input boxes are actually `AtomInput` React components. It is assumed that since the `componentDidMount` sets up an atom command to handle saving when the enter key is pressed with the dialog focused (https://github.com/facebook/nuclide/blob/master/pkg/nuclide-remote-projects/lib/CreateConnectionProfileForm.js#L71) that this case is handled. However, the input box for the password field is not `AtomInput` but a regular `input` box.

Fix:
Instead of passing in an empty function, pass in the `_clickSave` handler. This function is then called in `ConnectionDetailsForm` at https://github.com/facebook/nuclide/blob/master/pkg/nuclide-remote-projects/lib/ConnectionDetailsForm.js#L85 when the Enter key is pressed.

Before:
https://i.imgur.com/sxi8G7N.gifv

After:
https://i.imgur.com/34rLybr.gifv