### PR TITLE
nuclide-clang-rpc: Use `python2.7` because `python` could be Python 3

### DIFF
--- a/pkg/nuclide-clang-rpc/lib/find-clang-server-args.js
+++ b/pkg/nuclide-clang-rpc/lib/find-clang-server-args.js
@@ -55,7 +55,7 @@ export default async function findClangServerArgs(): Promise<ClangServerArgs> {
 
   const clangServerArgs = {
     libClangLibraryFile,
-    pythonExecutable: 'python',
+    pythonExecutable: 'python2.7',
     pythonPathEnv: nuclideUri.join(__dirname, '../VendorLib'),
   };
   if (typeof fbFindClangServerArgs === 'function') {


### PR DESCRIPTION
On Arch Linux, `/usr/bin/python` is Python 3, but Python 2.7 is expected. `/usr/bin/python2.7` seems to exist on Arch Linux, Ubuntu and OS X, so that should be more reliable.