### PR TITLE
Fixed infinite loop when trying to find a mercurial repo

### DIFF
--- a/pkg/nuclide-source-control-helpers/lib/hg-repository.js
+++ b/pkg/nuclide-source-control-helpers/lib/hg-repository.js
@@ -35,7 +35,7 @@ export default function findHgRepository(startDirectoryPath: string): ?HgReposit
       }
       return {repoPath, originURL, workingDirectoryPath};
     }
-    const parentDir = nuclideUri.join(workingDirectoryPath, '..');
+    const parentDir = nuclideUri.join(workingDirectoryPath);
     if (parentDir === workingDirectoryPath) {
       return null;
     } else {


### PR DESCRIPTION
Fixes #726 
I made this change and it worked, I am no longer getting 100% CPU usage. I also ran `npm run test` and it gave me no errors related to this file. But it seems Nuclide does not have automated tests? The `test` script only runs `eslint` and `flow`. I am not sure if this change is going to break any mercurial related code, please someone review this.