### PR TITLE
Remove SourceKitten compilerargs flag

### DIFF
--- a/pkg/nuclide-swift/lib/taskrunner/providers/SwiftPMAutocompletionProvider.js
+++ b/pkg/nuclide-swift/lib/taskrunner/providers/SwiftPMAutocompletionProvider.js
@@ -46,7 +46,7 @@ export default class SwiftPMAutocompletionProvider {
     const result = await asyncExecuteSourceKitten('complete', [
       '--text', request.editor.getText(),
       '--offset', String(offset),
-      '--compilerargs', '--',
+      '--',
       compilerArgs ? compilerArgs : '',
     ]);
 


### PR DESCRIPTION
This flag has been removed from SourceKitten in favor of just taking all
arguments after `--` as compiler arguments.

See https://github.com/jpsim/SourceKitten/pull/231 and https://github.com/facebook/nuclide/issues/747 for context