### PR TITLE
Updated information about Flow Windows support

### DIFF
--- a/docs/_docs/languages/flow.md
+++ b/docs/_docs/languages/flow.md
@@ -7,13 +7,14 @@ permalink: /docs/languages/flow/
 
 Nuclide has deep, built in support for [Flow-enabled](http://flowtype.org) JavaScript.
 
-> Currently, Flow is [not supported on Windows](https://github.com/facebook/flow/issues/6), so this
-> integration is not yet available on that platform.
-
 <br/>
 
 * TOC
 {:toc}
+
+## Flow on Windows
+
+Flow recently became supported on Windows.  See the [Windows is Supported!](https://flowtype.org/blog/2016/08/01/Windows-Support.html) Flow blog post for more information.
 
 ## Installing Flow
 


### PR DESCRIPTION
Added a link to the Flow blog post about Windows support rather than only deleting the statement that Windows wasn't supported due to some users experiencing issues.

Related to Issue #748 