### PR TITLE
Show notification when waiting on remote file

### DIFF
--- a/pkg/nuclide-remote-atom-rpc/bin/CommandClient.js
+++ b/pkg/nuclide-remote-atom-rpc/bin/CommandClient.js
@@ -72,10 +72,11 @@ export function openFile(
   filePath: NuclideUri,
   line: number,
   column: number,
+  isWaiting: boolean,
 ): Observable<AtomFileEvent> {
   return Observable.fromPromise(getCommands())
     .flatMap(commands => {
-      return commands.openFile(filePath, line, column).refCount();
+      return commands.openFile(filePath, line, column, isWaiting).refCount();
     });
 }
 
@@ -85,10 +86,11 @@ export function openRemoteFile(
   filePath: NuclideUri,
   line: number,
   column: number,
+  isWaiting: boolean,
 ): Observable<AtomFileEvent> {
   return Observable.fromPromise(getCommands())
     .flatMap(commands => {
-      return commands.openRemoteFile(filePath, line, column).refCount();
+      return commands.openRemoteFile(filePath, line, column, isWaiting).refCount();
     });
 }
 

--- a/pkg/nuclide-remote-atom-rpc/bin/main.js
+++ b/pkg/nuclide-remote-atom-rpc/bin/main.js
@@ -99,7 +99,7 @@ async function main(argv): Promise<number> {
     const isDirectory = await getIsDirectory(realpath);
     try {
       if (nuclideUri.isRemote(realpath)) {
-        const result = openRemoteFile(realpath, line, column, !!argv.wait);
+        const result = openRemoteFile(realpath, line, column, Boolean(argv.wait));
         if (argv.wait) {
           // eslint-disable-next-line babel/no-await-in-loop
           await result.toPromise();
@@ -112,7 +112,7 @@ async function main(argv): Promise<number> {
         // eslint-disable-next-line babel/no-await-in-loop
         await addProject(realpath);
       } else {
-        const result = openFile(realpath, line, column, !!argv.wait);
+        const result = openFile(realpath, line, column, Boolean(argv.wait));
         if (argv.wait) {
           // eslint-disable-next-line babel/no-await-in-loop
           await result.toPromise();

--- a/pkg/nuclide-remote-atom-rpc/bin/main.js
+++ b/pkg/nuclide-remote-atom-rpc/bin/main.js
@@ -99,7 +99,7 @@ async function main(argv): Promise<number> {
     const isDirectory = await getIsDirectory(realpath);
     try {
       if (nuclideUri.isRemote(realpath)) {
-        const result = openRemoteFile(realpath, line, column);
+        const result = openRemoteFile(realpath, line, column, !!argv.wait);
         if (argv.wait) {
           // eslint-disable-next-line babel/no-await-in-loop
           await result.toPromise();
@@ -112,7 +112,7 @@ async function main(argv): Promise<number> {
         // eslint-disable-next-line babel/no-await-in-loop
         await addProject(realpath);
       } else {
-        const result = openFile(realpath, line, column);
+        const result = openFile(realpath, line, column, !!argv.wait);
         if (argv.wait) {
           // eslint-disable-next-line babel/no-await-in-loop
           await result.toPromise();

--- a/pkg/nuclide-remote-atom-rpc/lib/rpc-types.js
+++ b/pkg/nuclide-remote-atom-rpc/lib/rpc-types.js
@@ -17,11 +17,13 @@ export interface AtomCommands {
     filePath: NuclideUri,
     line: number,
     column: number,
+    isWaiting: boolean,
   ): ConnectableObservable<AtomFileEvent>,
   openRemoteFile(
     uri: string,
     line: number,
     column: number,
+    isWaiting: boolean,
   ): ConnectableObservable<AtomFileEvent>,
   addProject(projectPath: NuclideUri): Promise<void>,
   dispose(): void,

--- a/pkg/nuclide-remote-atom/lib/main.js
+++ b/pkg/nuclide-remote-atom/lib/main.js
@@ -95,7 +95,7 @@ function openFile(
         if (
           nuclideUri.isRemote(uri) &&
           isWaiting &&
-          featureConfig.get('nuclide-remote-atom.shouldNotifyOnRemoteFileOpen')
+          featureConfig.get('nuclide-remote-atom.shouldNotifyWhenRemoteServerIsWaitingOnFile')
         ) {
           const notification = atom.notifications.addInfo(
             `The remote server has opened \`${nuclideUri.parse(uri).path}\` and is waiting for it to be closed.`, {

--- a/pkg/nuclide-remote-atom/lib/main.js
+++ b/pkg/nuclide-remote-atom/lib/main.js
@@ -93,14 +93,22 @@ function openFile(
         atom.applicationDelegate.focusWindow();
 
         if (
-          nuclideUri.isRemote(uri) &&
           isWaiting &&
-          featureConfig.get('nuclide-remote-atom.shouldNotifyWhenRemoteServerIsWaitingOnFile')
+          featureConfig.get('nuclide-remote-atom.shouldNotifyWhenCommandLineIsWaitingOnFile')
         ) {
           const notification = atom.notifications.addInfo(
-            `The remote server has opened \`${nuclideUri.parse(uri).path}\` and is waiting for it to be closed.`, {
+            `The command line has opened \`${nuclideUri.getPath(uri)}\` and is waiting for it to be closed.`, {
               dismissable: true,
               buttons: [{
+                onDidClick: () => {
+                  featureConfig.set(
+                    'nuclide-remote-atom.shouldNotifyWhenCommandLineIsWaitingOnFile',
+                    false,
+                  );
+                  notification.dismiss();
+                },
+                text: 'Don\'t show again',
+              }, {
                 onDidClick: () => {
                   editor.destroy();
                 },

--- a/pkg/nuclide-remote-atom/lib/main.js
+++ b/pkg/nuclide-remote-atom/lib/main.js
@@ -21,9 +21,11 @@ import {
 } from '../../nuclide-remote-connection';
 import {goToLocation} from '../../commons-atom/go-to-location';
 import createPackage from '../../commons-atom/createPackage';
+import * as featureConfig from '../../commons-atom/featureConfig';
 import {observeEditorDestroy} from '../../commons-atom/text-editor';
 import {Observable} from 'rxjs';
 import {ServerConnection} from '../../nuclide-remote-connection';
+import nuclideUri from '../../commons-node/nuclideUri';
 
 // Use dummy 0 port for local connections.
 const DUMMY_LOCAL_PORT = 0;
@@ -36,44 +38,24 @@ class Activation {
   constructor() {
     this._commands = {
       openFile(
-        filePath: NuclideUri,
+        uri: NuclideUri,
         line: number,
         column: number,
+        isWaiting: boolean,
       ): ConnectableObservable<AtomFileEvent> {
-        return Observable.fromPromise(
-          goToLocation(filePath, line, column)
-            .then(editor => {
-              atom.applicationDelegate.focusWindow();
-              return editor;
-            }),
-        )
-        .switchMap(editor =>
-          Observable.merge(
-            Observable.of('open'),
-            observeEditorDestroy(editor).map(value => 'close')))
-        .publish();
+        return openFile(uri, line, column, isWaiting);
       },
       openRemoteFile(
-        uri: string,
+        uri: NuclideUri,
         line: number,
         column: number,
+        isWaiting: boolean,
       ): ConnectableObservable<AtomFileEvent> {
         if (ServerConnection.getForUri(uri) == null) {
           return Observable.throw(new Error(`Atom is not connected to host for ${uri}`))
             .publish();
         }
-        return Observable.fromPromise(
-          goToLocation(uri, line, column)
-            .then(editor => {
-              atom.applicationDelegate.focusWindow();
-              return editor;
-            }),
-        )
-        .switchMap(editor =>
-          Observable.merge(
-            Observable.of('open'),
-            observeEditorDestroy(editor).map(value => 'close')))
-        .publish();
+        return openFile(uri, line, column, isWaiting);
       },
       addProject(projectPath: NuclideUri): Promise<void> {
         atom.project.addPath(projectPath);
@@ -97,6 +79,47 @@ class Activation {
     this._disposables.dispose();
   }
 
+}
+
+function openFile(
+  uri: NuclideUri,
+  line: number,
+  column: number,
+  isWaiting: boolean,
+): ConnectableObservable<AtomFileEvent> {
+  return Observable.fromPromise(
+    goToLocation(uri, line, column)
+      .then(editor => {
+        atom.applicationDelegate.focusWindow();
+
+        if (
+          nuclideUri.isRemote(uri) &&
+          isWaiting &&
+          featureConfig.get('nuclide-remote-atom.shouldNotifyOnRemoteFileOpen')
+        ) {
+          const notification = atom.notifications.addInfo(
+            `The remote server has opened \`${nuclideUri.parse(uri).path}\` and is waiting for it to be closed.`, {
+              buttons: [{
+                onDidClick: () => {
+                  editor.destroy();
+                },
+                text: 'Close file',
+              }],
+            },
+          );
+          editor.onDidDestroy(() => {
+            notification.dismiss();
+          });
+        }
+
+        return editor;
+      }),
+  )
+  .switchMap(editor =>
+    Observable.merge(
+      Observable.of('open'),
+      observeEditorDestroy(editor).map(value => 'close')))
+  .publish();
 }
 
 export default createPackage(Activation);

--- a/pkg/nuclide-remote-atom/lib/main.js
+++ b/pkg/nuclide-remote-atom/lib/main.js
@@ -99,6 +99,7 @@ function openFile(
         ) {
           const notification = atom.notifications.addInfo(
             `The remote server has opened \`${nuclideUri.parse(uri).path}\` and is waiting for it to be closed.`, {
+              dismissable: true,
               buttons: [{
                 onDidClick: () => {
                   editor.destroy();

--- a/pkg/nuclide-remote-atom/package.json
+++ b/pkg/nuclide-remote-atom/package.json
@@ -8,11 +8,11 @@
     "packageType": "Atom",
     "testRunner": "apm",
     "config": {
-      "shouldNotifyWhenRemoteServerIsWaitingOnFile": {
-        "title": "Notify when the remote server is waiting on an open file.",
+      "shouldNotifyWhenCommandLineIsWaitingOnFile": {
+        "title": "Notify when the command line is waiting on an open file.",
         "type": "boolean",
-        "default": false,
-        "description": "Show a notification when a file is opened locally by the remote server and the remote server is waiting for the file to be closed."
+        "default": true,
+        "description": "Show a notification when a file is opened locally and the command line is waiting for the file to be closed."
       }
     }
   },

--- a/pkg/nuclide-remote-atom/package.json
+++ b/pkg/nuclide-remote-atom/package.json
@@ -6,7 +6,15 @@
   "description": "Client side of command-line interface for communicating with nuclide-server",
   "nuclide": {
     "packageType": "Atom",
-    "testRunner": "apm"
+    "testRunner": "apm",
+    "config": {
+      "shouldNotifyWhenRemoteServerIsWaitingOnFile": {
+        "title": "Notify when the remote server is waiting on an open file.",
+        "type": "boolean",
+        "default": false,
+        "description": "Show a notification when a file is opened locally by the remote server and the remote server is waiting for the file to be closed."
+      }
+    }
   },
   "atomTestRunner": "../../lib/test-runner.js"
 }


### PR DESCRIPTION
When the nuclide RPC mechanism is used to open a file locally from a remote server, it can sometimes get lost in the noise. If you are using a local nuclide as a remote editor, your terminal might be stalled while it waits for the file to be closed.

The feature is disabled by default behind a setting `shouldNotifyWhenRemoteServerIsWaitingOnFile`.