### PR TITLE
Remove `baseURL` from main config - create dev config

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ This directory will contain the user and feature documentation for Nuclide.
 5. Run Jekyll's server.
 
     ```
-    bundle exec jekyll serve --incremental
+    bundle exec jekyll serve --config=_config.yml,_config_local_dev.yml --incremental
     ```
 
 6. The site will be served from http://localhost:4000.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,11 +9,6 @@ description: >
 
   It provides a first-class development environment for React Native, Hack and Flow projects.
 
-# baseurl determines the subpath of your site. For example if you're using an
-# organisation.github.io/reponame/ basic site URL, then baseurl would be set
-# as "/reponame/" but leave blank if you have a top-level domain URL.
-# Good description of url and baseurl here: https://byparker.com/blog/2014/clearing-up-confusion-around-baseurl/
-baseurl: ""
 url: "http://nuclide.io" # the base hostname & protocol for your site
 ghrepo: "facebook/nuclide"
 

--- a/docs/_config_local_dev.yml
+++ b/docs/_config_local_dev.yml
@@ -1,0 +1,6 @@
+# Local development config settings to over-ride base.
+# `jekyll serve` will by default generate a webserver at localhost:4000, so
+# only change `url` if you're using a non-default location. 
+
+baseurl: ""
+url: "http://127.0.0.1:4000"


### PR DESCRIPTION
We are having issues recently that //any// commits to the nuclide
docs are causing an extra `/nuclide/` to be added to the asset path

e.g.,

https://nuclide.io/nuclide/....

And thus causing problems rendering pages.

Not sure why -- so testing things out.

- Removed `baseURL` from the main `_config.yml`.
- Created a dev `_config_local_dev.yml` to be passed to your local Jekyll server for testing and overriding some settings
- Updated README to reflect this