### PR TITLE
Changed text in Context View Panel

### DIFF
--- a/pkg/nuclide-context-view/lib/ContextViewPanel.js
+++ b/pkg/nuclide-context-view/lib/ContextViewPanel.js
@@ -37,7 +37,7 @@ export const ContextViewPanel = (props: Props) => {
         <Header onHide={props.onHide} locked={props.locked} />
         <div className="nuclide-context-view-content">
           <p>
-            Place your cursor over a symbol to see more information about it.
+            Click on a symbol to see more information about it.
           </p>
           {props.children}
         </div>


### PR DESCRIPTION
Changed the instruction text at the top of the Context View Panel to indicate the user has to click on a symbol not just place their cursor over a symbol to see more information.