### PR TITLE
Updating Node language (Fixes #821)

### DIFF
--- a/docs/_docs/advanced-topics/building-from-source.md
+++ b/docs/_docs/advanced-topics/building-from-source.md
@@ -19,7 +19,7 @@ You must have the [general prerequisites](/docs/editor/setup#mac__prerequisites)
 addition, you must have
 
 - Xcode (for Command Line Tools)
-- A version of Node that is equal to or greater than that specified in ["node" (under "engines") in the package information](https://github.com/facebook/nuclide/blob/master/package.json)
+- A version of [Node](https://nodejs.org/) that is equal to or greater than that specified in ["node" (under "engines") in the package information](https://github.com/facebook/nuclide/blob/master/package.json).
 - Atom Shell Commands (open Atom and go to `Atom | Install Shell Commands`) installed as well.
 
 > Xcode can be installed from the App Store. Installation can take a *long, long* time. So be patient.

--- a/docs/_docs/features/remote.md
+++ b/docs/_docs/features/remote.md
@@ -26,7 +26,7 @@ The remote machine must meet certain prerequisites before the
 
 - [Python](https://www.python.org/) 2.6 or later. In many cases, this will already be installed by
 default on your OS distribution.
-- [Node](https://nodejs.org/) 5.10.0 or later.
+- A version of [Node](https://nodejs.org/) that is equal to or greater than that specified in ["node" (under "engines") in the package information](https://github.com/facebook/nuclide/blob/master/package.json).
 - `node` and `npm` must be in your `$PATH` environment variable.
 - [Watchman](https://facebook.github.io/watchman). The Nuclide server
 requires Watchman to detect file and directory changes. Follow the Watchman


### PR DESCRIPTION
Fixes #821

Updated the Node version language in Remote Development to match other places. And updated the Build from Source doc to link to the Node website.