### PR TITLE
Update Watchman language to be a stronger recommendation (Fixes #432)

### DIFF
--- a/docs/_docs/editor/setup.md
+++ b/docs/_docs/editor/setup.md
@@ -127,6 +127,7 @@ Recommended packages include:
 - [`sort-lines`](https://atom.io/packages/sort-lines) to enable sorting lines of text.
 - [`language-ocaml`](https://atom.io/packages/language-ocaml) to enable [OCaml](/docs/languages/other/#ocaml) language syntax highlighting.
 - [`language-babel`](https://atom.io/packages/language-babel) to enable language grammar for [JS, Flow and React JS](/docs/languages/flow/), etc.
+- [Watchman](https://facebook.github.io/watchman/) - version 3.2 or above. It must be in `/usr/local/bin/` or in your `$PATH` environment variable. Without Watchman, Nuclide will lose some functionality of its [Mercurial](/docs/features/hg), [Remote Development](/docs/features/remote), and [Quick Open](/docs/quick-start/getting-started/#quick-open) features.
 - ...and [others](https://github.com/facebook/nuclide/blob/master/package.json) under `package-deps`.
 
 In order to install all of the recommended packages, go to
@@ -149,7 +150,3 @@ To benefit from all of Nuclide's features, we recommend you also install the fol
 * [Flow](/docs/languages/flow/)
 * [Hack](/docs/languages/hack/)
 * [Mercurial](/docs/features/hg/)
-* [Watchman](https://facebook.github.io/watchman/) - version 3.2 or above. It must be in
-  `/usr/local/bin/` or in your `$PATH` environment variable. Without Watchman, Nuclide will lose some functionality of
-  its [Mercurial](/docs/features/hg), [Remote Development](/docs/features/remote), and
-  [Quick Open](/docs/quick-start/getting-started/#quick-open) features.

--- a/docs/_docs/quick-start/getting-started.md
+++ b/docs/_docs/quick-start/getting-started.md
@@ -24,10 +24,7 @@ apm install nuclide
 > Nuclide can be installed on [Windows](#windows), but it is
 > [not fully supported](https://github.com/facebook/nuclide/issues/401).
 
-While technically optional, in order for features such as [Quick Open](#quick-open) to work
-correctly, you also need to install [Watchman](https://facebook.github.io/watchman/) and
-ensure it is in your `$PATH` environment variable. There are other
-[recommended package installations](/docs/editor/setup/#post-installation) as well.
+If you want features such as [Quick Open](#quick-open), [Remote Development](/docs/features/remote), and [Mercurial support](/docs/features/hg) to work correctly, you also need to install [Watchman](https://facebook.github.io/watchman/) and ensure it is in your `$PATH` environment variable. There are other [recommended package installations](/docs/editor/setup/#post-installation) as well.
 
 ## Launch
 


### PR DESCRIPTION
Fixes #432

Moved Watchmen from Other Installations to Post Installation Recommended Packages in the Setup doc.  And got rid of the optional language and strengthened the these things won't work language in the Getting Started doc.