### PR TITLE
Replace Test Runner with Context View on home page

### DIFF
--- a/pkg/nuclide-context-view/lib/main.js
+++ b/pkg/nuclide-context-view/lib/main.js
@@ -17,6 +17,7 @@ import type {ContextViewConfig} from './ContextViewManager';
 import type {DefinitionService} from '../../nuclide-definition-service';
 import type {DistractionFreeModeProvider} from '../../nuclide-distraction-free-mode';
 import type {GetToolBar} from '../../commons-atom/suda-tool-bar';
+import type {HomeFragments} from '../../nuclide-home/lib/types';
 
 import {ContextViewManager} from './ContextViewManager';
 import {Disposable, CompositeDisposable} from 'atom';
@@ -159,4 +160,22 @@ export function getDistractionFreeModeProvider(): DistractionFreeModeProvider {
 
 export function provideNuclideContextView(): NuclideContextView {
   return Service;
+}
+
+export function getHomeFragments(): HomeFragments {
+  return {
+    feature: {
+      title: 'Context View',
+      icon: 'list-unordered',
+      description: 'Easily navigate between symbols and their definitions in your code',
+      command: () => {
+        atom.commands.dispatch(
+          atom.views.getView(atom.workspace),
+          'nuclide-context-view:toggle',
+          {visible: true},
+        );
+      },
+    },
+    priority: 2,
+  };
 }

--- a/pkg/nuclide-context-view/package.json
+++ b/pkg/nuclide-context-view/package.json
@@ -22,6 +22,11 @@
     }
   },
   "providedServices": {
+    "nuclide-home.homeFragments": {
+      "versions": {
+        "0.0.0": "getHomeFragments"
+      }
+    },
     "nuclide-context-view": {
       "versions": {
         "0.0.0": "provideNuclideContextView"

--- a/pkg/nuclide-test-runner/lib/main.js
+++ b/pkg/nuclide-test-runner/lib/main.js
@@ -10,7 +10,6 @@
  */
 
 import type FileTreeContextMenu from '../../nuclide-file-tree/lib/FileTreeContextMenu';
-import type {HomeFragments} from '../../nuclide-home/lib/types';
 import type {DistractionFreeModeProvider} from '../../nuclide-distraction-free-mode';
 import type {TestRunner} from './types';
 import type {TestRunnerControllerState} from './TestRunnerController';
@@ -292,18 +291,6 @@ export function addItemsToFileTreeContextMenu(contextMenu: FileTreeContextMenu):
 export function consumeToolBar(getToolBar: GetToolBar): IDisposable {
   invariant(activation);
   return activation.addToolBar(getToolBar);
-}
-
-export function getHomeFragments(): HomeFragments {
-  return {
-    feature: {
-      title: 'Test Runner',
-      icon: 'checklist',
-      description: 'Run tests directly from Nuclide by right-mouse-clicking on the file.',
-      command: 'nuclide-test-runner:toggle-panel',
-    },
-    priority: 2,
-  };
 }
 
 export function getDistractionFreeModeProvider(): DistractionFreeModeProvider {

--- a/pkg/nuclide-test-runner/package.json
+++ b/pkg/nuclide-test-runner/package.json
@@ -27,11 +27,6 @@
     }
   },
   "providedServices": {
-    "nuclide-home.homeFragments": {
-      "versions": {
-        "0.0.0": "getHomeFragments"
-      }
-    },
     "nuclide-distraction-free-mode": {
       "versions": {
         "0.0.0": "getDistractionFreeModeProvider"


### PR DESCRIPTION
The test runner needs some work. The context view is more full featured.
The latter currently will be of more use to the general Nuclide user at
this point. So swap them on the home page.
