### PR TITLE
[nuclide][homepage] Fix icon for context view on home page try it menu

### DIFF
--- a/pkg/nuclide-context-view/lib/main.js
+++ b/pkg/nuclide-context-view/lib/main.js
@@ -166,7 +166,7 @@ export function getHomeFragments(): HomeFragments {
   return {
     feature: {
       title: 'Context View',
-      icon: 'list-unordered',
+      icon: 'info',
       description: 'Easily navigate between symbols and their definitions in your code',
       command: () => {
         atom.commands.dispatch(


### PR DESCRIPTION
I put the outline view icon instead of the context view icon.

(see: https://github.com/facebook/nuclide/commit/c51bf570e7e6b608a1b5c19a1f903c7d82bc3971)

Test Plan: Visual