### PR TITLE
Support flow error reporting for missing props

### DIFF
--- a/pkg/nuclide-flow/lib/FlowDiagnosticsProvider.js
+++ b/pkg/nuclide-flow/lib/FlowDiagnosticsProvider.js
@@ -70,13 +70,12 @@ function flowMessageToTrace(message: MessageComponent): Trace {
 }
 
 function flowMessageToDiagnosticMessages(diagnostic: Diagnostic) {
-  const mainMessage = diagnostic.messageComponents[0];
   const messages = [];
   let trace = null;
 
   // The Flow type does not capture this, but the first message always has a path, and the
   // diagnostics package requires a FileDiagnosticMessage to have a path.
-  const path = extractPath(mainMessage);
+  const path = extractPath(diagnostic.messageComponents[0]);
   invariant(path != null, 'Expected path to not be null or undefined');
 
   const description = diagnostic.messageComponents[0].descr;

--- a/pkg/nuclide-flow/lib/FlowDiagnosticsProvider.js
+++ b/pkg/nuclide-flow/lib/FlowDiagnosticsProvider.js
@@ -69,35 +69,56 @@ function flowMessageToTrace(message: MessageComponent): Trace {
   };
 }
 
-function flowMessageToDiagnosticMessage(diagnostic: Diagnostic) {
-  const flowMessage = diagnostic.messageComponents[0];
+function flowMessageToDiagnosticMessages(diagnostic: Diagnostic) {
+  const mainMessage = diagnostic.messageComponents[0];
+  const messages = [];
+  let trace = null;
 
   // The Flow type does not capture this, but the first message always has a path, and the
   // diagnostics package requires a FileDiagnosticMessage to have a path.
-  const path = extractPath(flowMessage);
+  const path = extractPath(mainMessage);
   invariant(path != null, 'Expected path to not be null or undefined');
 
-  const diagnosticMessage: FileDiagnosticMessage = {
-    scope: 'file',
-    providerName: 'Flow',
-    type: diagnostic.level === 'error' ? 'Error' : 'Warning',
-    text: flowMessage.descr,
-    filePath: path,
-    range: extractRange(flowMessage),
-  };
-
-  const fix = flowMessageToFix(diagnostic);
-  if (fix != null) {
-    diagnosticMessage.fix = fix;
-  }
+  const description = diagnostic.messageComponents[0].descr;
 
   // When the message is an array with multiple elements, the second element
   // onwards comprise the trace for the error.
   if (diagnostic.messageComponents.length > 1) {
-    diagnosticMessage.trace = diagnostic.messageComponents.slice(1).map(flowMessageToTrace);
+    trace = diagnostic.messageComponents.slice(1).map(flowMessageToTrace);
   }
 
-  return diagnosticMessage;
+  // A single error can map to multiple locations in code.
+  // Iterate through each message component to cover all error ranges.
+  for (const message of diagnostic.messageComponents) {
+    const filePath = extractPath(message);
+
+    if (!filePath) {
+      continue;
+    }
+
+    const diagnosticMessage: FileDiagnosticMessage = {
+      scope: 'file',
+      providerName: 'Flow',
+      type: diagnostic.level === 'error' ? 'Error' : 'Warning',
+      text: description,
+      range: extractRange(message),
+      filePath,
+    };
+
+    const fix = flowMessageToFix(diagnostic);
+    if (fix != null) {
+      diagnosticMessage.fix = fix;
+    }
+
+    if (trace != null) {
+      diagnosticMessage.trace = trace;
+    }
+
+    messages.push(diagnosticMessage);
+  }
+
+
+  return messages;
 }
 
 class FlowDiagnosticsProvider {
@@ -220,9 +241,9 @@ class FlowDiagnosticsProvider {
     currentFile: string,
   ): DiagnosticProviderUpdate {
 
-    // convert array messages to Error Objects with Traces
-    const fileDiagnostics = diagnostics.map(flowMessageToDiagnosticMessage);
-
+    // convert array messages to array of Error Objects with Traces, and then flatten
+    const fileDiagnostics = diagnostics.map(flowMessageToDiagnosticMessages)
+                                       .reduce((a, b) => a.concat(b), []);
     const filePathToMessages = new Map();
 
     // This invalidates the errors in the current file. If Flow, when running in this root, has


### PR DESCRIPTION
Some flow messages have multiple error ranges, the flow diag tool should show the error highlight for all ranges.

This allows prop validation like this:
![screen shot 2016-10-28 at 12 02 06](https://cloud.githubusercontent.com/assets/2582698/19802920/69d20a10-9d06-11e6-80fb-9f5a4a007d3a.png)
