### PR TITLE
[Lint] Skip parsing "arc lint" output when there are no linters

### DIFF
--- a/pkg/nuclide-arcanist-rpc/lib/ArcanistService.js
+++ b/pkg/nuclide-arcanist-rpc/lib/ArcanistService.js
@@ -273,26 +273,29 @@ async function execArcLint(
   const result = await niceCheckOutput('arc', args, getArcExecOptions(cwd));
 
   const output: Map<string, Array<Object>> = new Map();
-  // Arc lint outputs multiple JSON objects on mutliple lines. Split them, then merge the
-  // results.
-  for (const line of result.stdout.trim().split('\n')) {
-    let json;
-    try {
-      json = JSON.parse(line);
-    } catch (error) {
-      getLogger().warn('Error parsing `arc lint` JSON output', line);
-      continue;
-    }
-    for (const file of Object.keys(json)) {
-      const errorsToAdd = json[file];
-
-      let errors = output.get(file);
-      if (errors == null) {
-        errors = [];
-        output.set(file, errors);
+  // Arc lint prints nothing when there are no linters.
+  if (result.stdout !== '') {
+    // Arc lint outputs multiple JSON objects on multiple lines. Split them, then merge the
+    // results.
+    for (const line of result.stdout.trim().split('\n')) {
+      let json;
+      try {
+        json = JSON.parse(line);
+      } catch (error) {
+        getLogger().warn('Error parsing `arc lint` JSON output', line);
+        continue;
       }
-      for (const error of errorsToAdd) {
-        errors.push(error);
+      for (const file of Object.keys(json)) {
+        const errorsToAdd = json[file];
+
+        let errors = output.get(file);
+        if (errors == null) {
+          errors = [];
+          output.set(file, errors);
+        }
+        for (const error of errorsToAdd) {
+          errors.push(error);
+        }
       }
     }
   }


### PR DESCRIPTION
When there are no linters (ex: no .arclint file), shelling out to `arc lint` gets nothing back as output, just an empty string for stdout. Trying to split and JSON-parse the empty string causes Nuclide to print out a warning that says `Error parsing \`arc lint\` JSON output`. Avoiding the parse when there are no linters avoids this warning.