### PR TITLE
[nuclide-flow]: Make Flow autocomplete priority configurable

### DIFF
--- a/docs/_docs/languages/flow.md
+++ b/docs/_docs/languages/flow.md
@@ -59,6 +59,10 @@ built-in types provided by Flow, autocomplete just works.
 
 ![](/static/images/docs/language-flow-autocomplete.png)
 
+By default suggestions from Flow will be shown first in the list of autocomplete results.
+However if you don't want this behavior (e.g. you want snippets to be on top),
+you can configure priority in Nuclide's preferences.
+
 ### Jump To Definition
 
 Nuclide provides a jump to definition/symbol feature for Flow programs.

--- a/pkg/nuclide-flow/lib/main.js
+++ b/pkg/nuclide-flow/lib/main.js
@@ -71,13 +71,15 @@ export function activate() {
 /** Provider for autocomplete service. */
 export function createAutocompleteProvider(): atom$AutocompleteProvider {
   const excludeLowerPriority = Boolean(featureConfig.get('nuclide-flow.excludeOtherAutocomplete'));
+  const flowResultsFirst = Boolean(featureConfig.get('nuclide-flow.flowAutocompleteResultsFirst'));
 
   return {
     selector: JS_GRAMMARS.map(grammar => '.' + grammar).join(', '),
     disableForSelector: '.source.js .comment',
     inclusionPriority: 1,
-    // We want to get ranked higher than the snippets provider.
-    suggestionPriority: 5,
+    // We want to get ranked higher than the snippets provider by default,
+    // but it's configurable
+    suggestionPriority: flowResultsFirst ? 5 : 1,
     onDidInsertSuggestion: () => {
       track('nuclide-flow.autocomplete-chosen');
     },

--- a/pkg/nuclide-flow/package.json
+++ b/pkg/nuclide-flow/package.json
@@ -31,6 +31,12 @@
         "default": true,
         "description": "If Nuclide was responsible for starting a Flow server (on the client-side), stop it when Nuclide closes or reloads."
       },
+      "flowAutocompleteResultsFirst": {
+        "title": "Show Flow autocomplete results first",
+        "type": "boolean",
+        "default": true,
+        "description": "If checked, Flow suggestions will be placed before the rest of autocomplete results (e.g. snippets etc.). Requires restart to take effect."
+      },
       "excludeOtherAutocomplete": {
         "title": "Exclude other autocomplete results",
         "type": "boolean",


### PR DESCRIPTION
This PR adds preferences option to configure Flow's autocomplete results priority.