### PR TITLE
Add several missing methods to atom flow typedefs

### DIFF
--- a/pkg/nuclide-external-interfaces/1.0/atom.js
+++ b/pkg/nuclide-external-interfaces/1.0/atom.js
@@ -365,6 +365,7 @@ declare class atom$Pane {
   moveItemToPane(item: Object, pane: atom$Pane, index: number): void,
   destroyItem(item: Object): boolean,
   itemForURI(uri: string): Object,
+  getActiveEditor(): ?atom$TextEditor,
 
   // Event subscriptions.
   onDidAddItem(cb: (event: {item: Object, index: number}) => void): IDisposable,
@@ -660,6 +661,7 @@ declare class atom$TextEditor extends atom$Model {
   id: number,
   firstVisibleScreenRow: number,
   rowsPerPage: number,
+  element: atom$TextEditorElement,
 
   // Event Subscription
   onDidChange(callback: () => void): IDisposable,
@@ -735,6 +737,7 @@ declare class atom$TextEditor extends atom$Model {
       screenLine?: boolean,
     },
   ): atom$Point,
+  bufferRowForScreenRow(number): number,
   getVisibleRowRange(): ?[number, number],
 
   // Decorations
@@ -879,6 +882,7 @@ declare class atom$TextEditor extends atom$Model {
   tokenForBufferPosition(position: atom$Point | [?number, ?number]): atom$Token,
   onDidConflict(callback: () => void): IDisposable,
   serialize: () => mixed,
+  getElement(): atom$TextEditorElement,
 }
 
 /**
@@ -900,6 +904,7 @@ declare class atom$TextEditorComponent {
     linesClientRect?: {top: number, left: number, bottom: number, right: number},
   ): {top: number, left: number, bottom: number, right: number},
   invalidateBlockDecorationDimensions(decoration: atom$Decoration): void,
+  getVisibleRowRange: [?number, ?number],
 }
 
 /**
@@ -909,6 +914,7 @@ declare class atom$TextEditorComponent {
 declare class atom$TextEditorPresenter {
   startBlinkingCursors: () => void,
   stopBlinkingCursors(visible: boolean): void,
+  getVisibleRowRange: [?number, ?number],
 }
 
 /**
@@ -935,6 +941,8 @@ declare class atom$TextEditorElement extends HTMLElement {
     left: number,
     top: number,
   },
+
+  getVisibleRowRange(): [?number, ?number],
 
   setScrollTop(scrollTop: number): void,
   getScrollTop(): number,


### PR DESCRIPTION
Add some new atom flow defs

This adds a couple of type defs that I need for my atom plugin.

`npm run flow` produces errors for me, but does so on master as well... How should an external contributor be running flow to make sure we don't introduce new flow errors?

I assume these definitions will be moved to https://github.com/flowtype/flow-typed at some point, but understand that there are some issues with that. If there's anything I can do to help with that, let me know. I have a couple of weeks free.