### PR TITLE
Side Bar labels become Project Explorer

### DIFF
--- a/pkg/nuclide-side-bar/menus/nuclide-side-bar.json
+++ b/pkg/nuclide-side-bar/menus/nuclide-side-bar.json
@@ -3,14 +3,14 @@
     {
       "label": "View",
       "submenu": [
-        {"command": "nuclide-side-bar:toggle", "label": "Toggle Side Bar"}
+        {"command": "nuclide-side-bar:toggle", "label": "Toggle Project Explorer"}
       ]
     },
     {
       "label": "Nuclide",
       "submenu": [
         {
-          "label": "Side Bar",
+          "label": "Project Explorer",
           "submenu": [
             {
               "command": "nuclide-side-bar:toggle",

--- a/pkg/nuclide-source-control-side-bar/package.json
+++ b/pkg/nuclide-source-control-side-bar/package.json
@@ -9,7 +9,7 @@
     "configMetadata": {
       "pathComponents": [
         "Source Control",
-        "Sidebar"
+        "Project Explorer"
       ]
     },
     "config": {


### PR DESCRIPTION
Changed "Side Bar"/"Sidebar" labels in menus and Settings to be "Project Explorer" to match documentation.