### PR TITLE
Task Runner Debug buttons still had plug icon, updated to bug

### DIFF
--- a/pkg/nuclide-buck/lib/BuckBuildSystem.js
+++ b/pkg/nuclide-buck/lib/BuckBuildSystem.js
@@ -486,7 +486,7 @@ const TASKS = [
     label: 'Debug',
     description: 'Debug the specfied Buck target',
     runnable: true,
-    icon: 'plug',
+    icon: 'bug',
   },
 ];
 

--- a/pkg/nuclide-debugger-php/lib/main.js
+++ b/pkg/nuclide-debugger-php/lib/main.js
@@ -29,7 +29,7 @@ export function getHomeFragments(): HomeFragments {
   return {
     feature: {
       title: 'PHP Debugger',
-      icon: 'plug',
+      icon: 'bug',
       description: 'Connect to a PHP server process and debug Hack code from within Nuclide.',
       command: 'nuclide-debugger:toggle',
     },

--- a/pkg/nuclide-hhvm/lib/HhvmBuildSystem.js
+++ b/pkg/nuclide-hhvm/lib/HhvmBuildSystem.js
@@ -78,7 +78,7 @@ export default class HhvmBuildSystem {
         priority: 1,  // Take precedence over the Arcanist build toolbar.
         runnable: !disabled,
         cancelable: false,
-        icon: 'plug',
+        icon: 'bug',
       },
     ];
   }


### PR DESCRIPTION
The Debug buttons for Buck and HHVM in the Task Runner still had the plug icon.  Not sure where nuclide-debugger-php/lib/main.js affects but updated it too.  Also not 100% certain I referenced the correct icon.