### PR TITLE
Change RegExp dependency for url matching.

### DIFF
--- a/pkg/nuclide-url-hyperclick/lib/HyperclickProviderHelpers.js
+++ b/pkg/nuclide-url-hyperclick/lib/HyperclickProviderHelpers.js
@@ -30,7 +30,14 @@ export default class HyperclickProviderHelpers {
 
     urlregexp.lastIndex = 0;
 
-    const url = match[0];
+    let url = match[0];
+
+    // Stripping off quotes
+    if (url.includes('"'))
+      url = url.split('"')[0];
+    if (url.includes("'"))
+      url = url.split("'")[0];
+
     const index = match.index;
     const matchLength = url.length;
 


### PR DESCRIPTION
Hi,
The [current](https://www.npmjs.com/package/urlregexp) URL RegExp dependency doesn't find any url in text sample like `"http://example.com",` or if it does, it opens the URL `http://example.com",` which is not what we want.

So instead of using this library which includes quotes in its matching (I don't know if it is a relevant feature), I replaced it with this [one](https://www.npmjs.com/package/url-regex).