### PR TITLE
u[Nuclide] Fix bug in ReasonML / OCaml formatters.

### DIFF
--- a/pkg/nuclide-ocaml/lib/CodeFormatHelpers.js
+++ b/pkg/nuclide-ocaml/lib/CodeFormatHelpers.js
@@ -18,7 +18,7 @@ import featureConfig from '../../commons-atom/featureConfig';
 
 function isInterfaceF(filePath: string) {
   const ext = nuclideUri.extname(filePath);
-  return ext === 'rei' || ext === 'mli';
+  return ext === '.rei' || ext === '.mli';
 }
 
 function getRefmtFlags(): Array<string> {


### PR DESCRIPTION
Summary:The `extname`e function returns `.rei`/`.mli`, not `re`/`mli`.

Test Plan: Code formatting now works.

Reviewers:

CC: