### PR TITLE
Add information about the $FlowFB tag

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -118,3 +118,7 @@ Note that for packages whose test runner is `apm`, this is not necessary.
 ## Sample packages
 
 `sample-*` packages aren't loaded as part of Nuclide. They exist to illustrate archetypal architecture and structure for a given feature.
+
+## Flow errors
+
+In case flow complaints about missing modules, i.e `Required module not found`, try uncommenting the `$FlowFB` option in Nuclide's  [.flowconfig](https://github.com/facebook/nuclide/blob/master/.flowconfig) file. See https://github.com/facebook/nuclide/pull/906#issuecomment-263567813 for more information.

--- a/pkg/commons-node/process.js
+++ b/pkg/commons-node/process.js
@@ -433,6 +433,7 @@ export function observeProcess(
 
 let FB_INCLUDE_PATHS;
 try {
+  // $FlowFB
   FB_INCLUDE_PATHS = require('./fb-config').FB_INCLUDE_PATHS;
 } catch (error) {
   FB_INCLUDE_PATHS = [];

--- a/pkg/nuclide-debugger-native/lib/LLDBLaunchAttachProvider.js
+++ b/pkg/nuclide-debugger-native/lib/LLDBLaunchAttachProvider.js
@@ -38,7 +38,7 @@ export class LLDBLaunchAttachProvider extends DebuggerLaunchAttachProvider {
     this._loadAction(AttachActionUIProvider);
     this._loadAction(LaunchActionUIProvider);
     try {
-      // $FBFlow
+      // $FlowFB
       this._loadAction(require('./actions/fb-omActionUIProvider'));
     } catch (_) {}
   }

--- a/pkg/nuclide-debugger-php/lib/AttachProcessInfo.js
+++ b/pkg/nuclide-debugger-php/lib/AttachProcessInfo.js
@@ -81,7 +81,6 @@ export class AttachProcessInfo extends DebuggerProcessInfo {
       ),
     }];
     try {
-      // $FlowFB
       return customControlButtons.concat(require('./fb/services').customControlButtons);
     } catch (_) {
       return customControlButtons;


### PR DESCRIPTION
Add notice about the `$FlowFB` tag used in flow for non Facebook employees (see: https://github.com/facebook/nuclide/pull/906#issuecomment-263654932) to avoid errors similar to those listed here: https://github.com/facebook/nuclide/pull/906#issuecomment-263567813. 

This also fixes tree flow errors related to missing, misspelled or unused `$FlowFB` tags.

Ping @hansonw.