### PR TITLE
Swap navigation forward/backward keys on PCs

### DIFF
--- a/docs/_docs/editor/keyboard-shortcuts.md
+++ b/docs/_docs/editor/keyboard-shortcuts.md
@@ -166,8 +166,8 @@ These are keyboard shortcuts with respect to navigation within files, etc.
 
 | Key (macOS) | Key (Linux) | Command | Description |
 |-----------|-------------|---------|-------------|
-| `Ctrl-,` | `Ctrl-<` | `nuclide-navigation-stack:navigate-forwards` | Moves the cursor to the next position from the current, but former, position. |
-| `Ctrl-.` | `Ctrl->` | `nuclide-navigation-stack:navigate-backwards` | Moves the cursor to a previous position from the current position. |
+| `Ctrl-,` | `Ctrl-<` | `nuclide-navigation-stack:navigate-backwards` | Moves the cursor to a previous position from the current position. |
+| `Ctrl-.` | `Ctrl->` | `nuclide-navigation-stack:navigate-forwards` | Moves the cursor to the next position from the current, but former, position. |
 
 ## Miscellaneous
 


### PR DESCRIPTION
Windows and Linux used 'Ctrl-<' to go forwards and 'Ctrl->' to
go backwards in history.  This is opposite the expected direction.
Swap these two key definitions.

The Mac/OS X key definitions were correct, but the documentation also
had them backwards.  Swap the key definition descriptions in the
documentation.

A remaining issue appears to exist which blocks Ctrl-< since it is
bound to a different action by Atom-Core.  This change doesn't correct
that because it's a different issue and it's not obvious how it should
be fixed in Nuclide.

Fixup for #909