### PR TITLE
keymaps: Ctrl instead of Cmd on Linux/Windows

### DIFF
--- a/pkg/nuclide-context-view/keymaps/nuclide-context-view.json
+++ b/pkg/nuclide-context-view/keymaps/nuclide-context-view.json
@@ -1,5 +1,8 @@
 {
-  "atom-workspace": {
+  ".platform-darwin atom-workspace": {
     "cmd-i": "nuclide-context-view:toggle"
+  },
+  ".platform-win32 atom-workspace, .platform-linux atom-workspace": {
+    "ctrl-i": "nuclide-context-view:toggle"
   }
 }

--- a/pkg/nuclide-debugger/keymaps/Debugger.json
+++ b/pkg/nuclide-debugger/keymaps/Debugger.json
@@ -1,7 +1,13 @@
 {
-  "atom-workspace": {
+  ".platform-darwin atom-workspace": {
     "cmd-shift-y": "nuclide-debugger:toggle",
     "cmd-shift-a": "nuclide-debugger:toggle-launch-attach",
+  },
+  ".platform-win32 atom-workspace, .platform-linux atom-workspace": {
+    "ctrl-shift-y": "nuclide-debugger:toggle",
+    "ctrl-shift-a": "nuclide-debugger:toggle-launch-attach",
+  },
+  "atom-workspace": {
     "f8": "nuclide-debugger:continue-debugging",
     "shift-f8": "nuclide-debugger:run-to-location",
     "shift-f5": "nuclide-debugger:stop-debugging",


### PR DESCRIPTION
  * Ctrl-i for context-view-toggle
  * Ctrl-Shift-{a,y} for debugger{,-launch-attach}

This matches the current documentation already.