### PR TITLE
Drop `cheerio`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "atom-package-deps": "4.3.1",
     "babylon": "6.14.1",
     "chalk": "1.1.3",
-    "cheerio": "0.22.0",
     "classnames": "2.2.5",
     "connect": "3.5.0",
     "core-js": "2.4.1",


### PR DESCRIPTION
Please, correct me if I am wrong, but `nuclide` does not seem to use it anywhere.