### PR TITLE
Use Jekyll SEO Tag to generate head metadata for docs

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
-gem 'github-pages', '~> 104'
+
+gem 'github-pages', '~> 104', group: :jekyll_plugins

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,7 +20,7 @@ description: >
 # This was also be set to the right thing automatically for local development
 # https://github.com/blog/2277-what-s-new-in-github-pages-with-jekyll-3-3
 # http://jekyllrb.com/news/2016/10/06/jekyll-3-3-is-here/
-url: "http://nuclide.io"
+url: "https://nuclide.io"
 
 # Note: There are new filters in Jekyll 3.3 to help with absolute and relative urls
 # absolute_url

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,6 +8,7 @@ description: >
   Nuclide is built as a single package on top of Atom to provide hackability and the support of an active community.
 
   It provides a first-class development environment for React Native, Hack and Flow projects.
+logo: /static/og_image.png
 
 # baseurl determines the subpath of your site. For example if you're using an
 # organisation.github.io/reponame/ basic site URL, then baseurl would be set
@@ -86,3 +87,13 @@ color:
 # RSS Feed
 gems:
   - jekyll-feed
+  - jekyll-seo-tag
+  - jekyll-sitemap
+
+# Set default open graph image for all pages
+defaults:
+  -
+    scope:
+      path: ""
+    values:
+      image: /static/og_image.png

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -3,11 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <meta property="og:url" content="{{ page.url | replace:'index.html','' | absolute_url }}" />
-  <meta property="og:site_name" content="{{ site.title }}"/>
-  <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}" />
-  <meta property="og:image" content="{{ '/static/og_image.png' | absolute_url }}" />
-  <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}" />
+  {% seo %}
 
   {% comment %}
   For Algolia search
@@ -24,12 +20,6 @@
   the final destination to eliminate a redirect for clients.
   {% endcomment %}
   <script src="https://fbcdn-dragon-a.akamaihd.net/hphotos-ak-xaf1/t39.3284-6/11057093_524839387655092_169454193_n.js"></script>
-
-  <title>{% if page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
-  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ '/feed.xml' | absolute_url }}" />
 
   {% comment %}
   For our RSS feed.xml


### PR DESCRIPTION
A while back we released [Jekyll SEO Tag](https://github.com/jekyll/jekyll-seo-tag), an official Jekyll plugin designed to simplify adding SEO and social metadata to the template's `<head>` section.

This pull request removes some of the hard-coded logic from the head include, and instead, relies on Jekyll SEO Tag to do the heavy lifting (which includes battle-tested best practices and additional metadata not currently exposed).

Here's what the homepage looks like now:

```html
<meta property="og:url" content="http://nuclide.io/" />
  <meta property="og:site_name" content="Nuclide"/>
  <meta property="og:title" content="Nuclide" />
  <meta property="og:image" content="http://nuclide.io/static/og_image.png" />
  <meta property="og:description" content="Nuclide is built as a single package on top of Atom to provide hackability and the support of an active community.
It provides a first-class development environment for React Native, Hack and Flow projects.
" />
<title>Nuclide</title>
<meta name="description" content="Nuclide is built as a single package on top of Atom to provide hackability and the support of an active community.
It provides a first-class development environment for React Native, Hack and Flow projects.
">

<link rel="canonical" href="http://nuclide.io/">
```

Here's what it'd look like with Jekyll SEO Tag:

```html
<!-- Begin Jekyll SEO tag v2.1.0 -->
<title>Nuclide - Nuclide is built as a single package on top of Atom to provide hackability and the support of an active community. It provides a first-class development environment for React Native, Hack and Flow projects.</title>
<meta property="og:title" content="Nuclide" />
<meta name="description" content="Nuclide is built as a single package on top of Atom to provide hackability and the support of an active community. It provides a first-class development environment for React Native, Hack and Flow projects." />
<meta property="og:description" content="Nuclide is built as a single package on top of Atom to provide hackability and the support of an active community. It provides a first-class development environment for React Native, Hack and Flow projects." />
<link rel="canonical" href="http://localhost:4000/" />
<meta property="og:url" content="http://localhost:4000/" />
<meta property="og:site_name" content="Nuclide" />
<meta property="og:image" content="http://localhost:4000/static/og_image.png" />
<script type="application/ld+json">
{"@context": "http://schema.org",
"@type": "WebSite",
"name": "Nuclide",
"headline": "Nuclide",
"image": "http://localhost:4000/static/og_image.png",
"description": "Nuclide is built as a single package on top of Atom to provide hackability and the support of an active community. It provides a first-class development environment for React Native, Hack and Flow projects.",
"publisher": {"@type": "Organization",
"logo": {"@type": "ImageObject",
"url": "http://localhost:4000/static/og_image.png"}},
"url": "http://localhost:4000/"}</script>
<!-- End Jekyll SEO tag -->
```

You'll notice all the content is there, things like the hard line break in the description is removed, plus additional JSON-LD metadata is added for richer indexing.

The same is true for an individual doc. Here's what getting started looks like now:

```html
<meta property="og:url" content="http://nuclide.io/docs/quick-start/getting-started/" />
  <meta property="og:site_name" content="Nuclide"/>
  <meta property="og:title" content="Getting Started" />
  <meta property="og:image" content="http://nuclide.io/static/og_image.png" />
  <meta property="og:description" content="This getting started guide walks you through the core features of Nuclide and aims to get you productive quickly.  See Basics for more information on using N..." />
  <title>Getting Started | Nuclide</title>
  <meta name="description" content="This getting started guide walks you through the core features of Nuclide and aims to get you productive quickly.  See Basics for more information on using N...">
```

And using Jekyll SEO Tag:

```html
<!-- Begin Jekyll SEO tag v2.1.0 -->
<title>Getting Started - Nuclide</title>
<meta property="og:title" content="Getting Started" />
<meta name="description" content="This getting started guide walks you through the core features of Nuclide and aims to get you productive quickly. See Basics for more information on using Nuclide’s editing features." />
<meta property="og:description" content="This getting started guide walks you through the core features of Nuclide and aims to get you productive quickly. See Basics for more information on using Nuclide’s editing features." />
<link rel="canonical" href="http://localhost:4000/docs/quick-start/getting-started/" />
<meta property="og:url" content="http://localhost:4000/docs/quick-start/getting-started/" />
<meta property="og:site_name" content="Nuclide" />
<meta property="og:image" content="http://localhost:4000/static/og_image.png" />
<meta property="og:type" content="article" />
<meta property="article:published_time" content="2016-12-30T13:09:07-05:00" />
<script type="application/ld+json">
{"@context": "http://schema.org",
"@type": "BlogPosting",
"headline": "Getting Started",
"image": "http://localhost:4000/static/og_image.png",
"datePublished": "2016-12-30T13:09:07-05:00",
"description": "This getting started guide walks you through the core features of Nuclide and aims to get you productive quickly. See Basics for more information on using Nuclide’s editing features.",
"publisher": {"@type": "Organization",
"logo": {"@type": "ImageObject",
"url": "http://localhost:4000/static/og_image.png"}},
"url": "http://localhost:4000/docs/quick-start/getting-started/"}</script>
<!-- End Jekyll SEO tag -->
```

There should be no change to how the docs are authored or maintained to use the plugin. 

Additionally, I made four minor changes in support of the above:

* Output a sitemaps.org-compliant sitemap using Jekyll Sitemap (no configuration required)
* Hard code the site URL as HTTPS so things like the canonical URL are properly calculated as HTTPS
* Initialize the GitHub Pages plugin as part of the `:jekyll_plugins` group so it can properly set and enforce configuration defaults (so local development more closely matches production)
* Don't output the RSS feed metadata twice (`feed_meta` does that for you)

Really glad to see Nuclide using Jekyll and GitHub Pages for its documentation, and hope the above can help make the process a little easier.