### PR TITLE
Flow autocomplete: ignore prefix unless it's id.

### DIFF
--- a/pkg/nuclide-flow/lib/FlowAutocompleteProvider.js
+++ b/pkg/nuclide-flow/lib/FlowAutocompleteProvider.js
@@ -19,6 +19,8 @@ import passesGK from '../../commons-node/passesGK';
 
 import {getFlowServiceByNuclideUri} from './FlowServiceFactory';
 
+const ID_REGEX = /^[a-zA-Z_$][0-9a-zA-Z_$]*$/;
+
 export default class FlowAutocompleteProvider {
   _cacher: AutocompleteCacher<?Array<atom$AutocompleteSuggestion>>;
   constructor() {
@@ -74,7 +76,7 @@ export function shouldFilter(
   lastRequest: atom$AutocompleteRequest,
   currentRequest: atom$AutocompleteRequest,
 ): boolean {
-  const prefixIsIdentifier = /^[a-zA-Z_$][0-9a-zA-Z_$]*$/.test(currentRequest.prefix);
+  const prefixIsIdentifier = ID_REGEX.test(currentRequest.prefix);
   const previousPrefixIsDot = /^\s*\.\s*$/.test(lastRequest.prefix);
   const currentPrefixIsSingleChar = currentRequest.prefix.length === 1;
   const startsWithPrevious = currentRequest.prefix.length - 1 === lastRequest.prefix.length &&
@@ -134,9 +136,9 @@ function updateResults(
 }
 
 function getReplacementPrefix(originalPrefix: string): string {
-  // If it is just whitespace and punctuation, ignore it (this keeps us
-  // from eating leading dots).
-  return /^[\s.]*$/.test(originalPrefix) ? '' : originalPrefix;
+  // Ignore prefix unless it's an identifier (this keeps us from eating leading
+  // dots, colons, etc).
+  return ID_REGEX.test(originalPrefix) ? originalPrefix : '';
 }
 
 /**

--- a/pkg/nuclide-flow/spec/FlowAutocompleteProvider-spec.js
+++ b/pkg/nuclide-flow/spec/FlowAutocompleteProvider-spec.js
@@ -205,6 +205,18 @@ describe('FlowAutocompleteProvider', () => {
       });
     });
 
+    it('should not filter suggestions if the prefix is not a valid id', () => {
+      waitsForPromise(async () => {
+        activatedManually = true;
+        prefix = '{';
+        expect(
+          hasEqualElements(
+            await getNameSet(options),
+            new Set(optionNames)),
+        ).toBe(true);
+      });
+    });
+
     it('should rank better matches higher', () => {
       waitsForPromise(async () => {
         prefix = 'one';


### PR DESCRIPTION
I'm adding an autocomplete for GraphQL queries in Flow. In the following example Nuclide filters out all suggestions because the prefix is `" { "`.

```js
Relay.QL`query { <HERE> }`;
```

As far as I understand prefix filtering is only useful if prefix is an identifier.