### PR TITLE
fix jedi autocomplete for python 3

### DIFF
--- a/pkg/nuclide-python-rpc/python/jediserver.py
+++ b/pkg/nuclide-python-rpc/python/jediserver.py
@@ -53,7 +53,7 @@ class JediServer:
                 self.src.startswith(WORKING_DIR)]
 
     def generate_log_name(self, value):
-        hash = hashlib.md5(value).hexdigest()[:10]
+        hash = hashlib.md5(value.encode('utf-8')).hexdigest()[:10]
         return os.path.basename(value) + '-' + hash + '.log'
 
     def init_logging(self):


### PR DESCRIPTION
Previously I was receiving this error message

```
python /Users/dluna/github/nuclide/pkg/nuclide-python-rpc/python/jediserver.py -s /Users/dluna/github/DerpLearning/UNREAL/model.py
Traceback (most recent call last):
  File "/Users/dluna/github/nuclide/pkg/nuclide-python-rpc/python/jediserver.py", line 220, in <module>
    JediServer(args.src, args.paths).run()
  File "/Users/dluna/github/nuclide/pkg/nuclide-python-rpc/python/jediserver.py", line 38, in run
    self.init_logging()
  File "/Users/dluna/github/nuclide/pkg/nuclide-python-rpc/python/jediserver.py", line 64, in init_logging
    handler = FileHandler(os.path.join(log_dir, self.generate_log_name(self.src)))
  File "/Users/dluna/github/nuclide/pkg/nuclide-python-rpc/python/jediserver.py", line 56, in generate_log_name
    hash = hashlib.md5(value).hexdigest()[:10]
TypeError: Unicode-objects must be encoded before hashing
```

which prevented autocomplete, content view, definition view from working with Python 3.

```
Python 3.5.2 | packaged by conda-forge | (default, Sep  8 2016, 14:36:38) 
[GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.54)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
```
