### PR TITLE
Fix Python 3 crash in `generate_log_name()`

### DIFF
--- a/pkg/nuclide-python-rpc/python/jediserver.py
+++ b/pkg/nuclide-python-rpc/python/jediserver.py
@@ -53,7 +53,7 @@ class JediServer:
                 self.src.startswith(WORKING_DIR)]
 
     def generate_log_name(self, value):
-        hash = hashlib.md5(value).hexdigest()[:10]
+        hash = hashlib.md5(value.encode('utf-8')).hexdigest()[:10]
         return os.path.basename(value) + '-' + hash + '.log'
 
     def init_logging(self):


### PR DESCRIPTION
Fixes a `TypeError: Unicode-objects must be encoded before hashing` exception in Python 3. Tested using Python 3.5.1 and Python 2.7.