### PR TITLE
Repair Python outline pane for Python 3

### DIFF
--- a/pkg/nuclide-python-rpc/python/outline.py
+++ b/pkg/nuclide-python-rpc/python/outline.py
@@ -8,7 +8,7 @@ import jedi
 
 
 def serialize_names(names):
-    return filter(None, [serialize_name(n) for n in names])
+    return list(filter(None, [serialize_name(n) for n in names]))
 
 
 def serialize_name(name):


### PR DESCRIPTION
In Python 3, the output of `filter(…)` is not JSON serializable. Opening outline view when using Python 3 yields the following exception:

    TypeError: <filter object at 0x108b87e10> is not JSON serializable

The solution is to convert the output of `filter(…)` back to a list.