### PR TITLE
Improve autocomplete support for namespaced hack code

### DIFF
--- a/pkg/nuclide-hack-rpc/lib/Completions.js
+++ b/pkg/nuclide-hack-rpc/lib/Completions.js
@@ -111,7 +111,7 @@ function processCompletions(
     // current scope - so, if what the user typed didn't start with the
     // namespace (which would lead to us having a resultPrefix), we don't
     // want to put the namespace in the replacement.
-    const scopedName = resultPrefix === '' ? name.split("\\").pop() : name;
+    const scopedName = resultPrefix === '' ? name.split('\\').pop() : name;
     if (func_details != null) {
       return {
         ...commonResult,

--- a/pkg/nuclide-hack-rpc/lib/Completions.js
+++ b/pkg/nuclide-hack-rpc/lib/Completions.js
@@ -107,10 +107,15 @@ function processCompletions(
       replacementPrefix: resultPrefix === '' ? defaultPrefix : resultPrefix,
       description: matchTypeOfType(type),
     };
+    // The typechecker only gives us suggestions that are valid in the
+    // current scope - so, if what the user typed didn't start with the
+    // namespace (which would lead to us having a resultPrefix), we don't
+    // want to put the namespace in the replacement.
+    const scopedName = resultPrefix === '' ? name.split("\\").pop() : name;
     if (func_details != null) {
       return {
         ...commonResult,
-        snippet: matchSnippet(name, func_details.params),
+        snippet: matchSnippet(scopedName, func_details.params),
         leftLabel: func_details.return_type,
         rightLabel: paramSignature(func_details.params),
         type: 'function',
@@ -118,7 +123,7 @@ function processCompletions(
     } else {
       return {
         ...commonResult,
-        snippet: matchSnippet(name),
+        snippet: matchSnippet(scopedName),
         rightLabel: matchTypeOfType(type),
       };
     }


### PR DESCRIPTION
fixes #711

With thanks to @PranayAgarwal for similar fix to vscode: https://github.com/PranayAgarwal/vscode-hack/commit/7f702993dfb2ebc00afa28740a84661fbd57dba3

Test plan:

Have these clases defined:
 - `SomeNamespace\Foo`
 - `SomeOtherNamespace\Foo`
 - `Herp\Herp`

Write a class `SomeNamespace\Bar` - then:
 - `new Fo` autocompletes as `new Foo()`
 - `new \SomeOth` autocompletes as `new \SomeOtherNamespace\Foo()`
 - `new \Her` autocompletes as `new \Herp\Herp()`