### PR TITLE
Fix nuclide-adb-logcat parsing

### DIFF
--- a/pkg/nuclide-adb-logcat/lib/createProcessStream.js
+++ b/pkg/nuclide-adb-logcat/lib/createProcessStream.js
@@ -58,7 +58,7 @@ export function createProcessStream(): Observable<string> {
   )
     // Only get the text from stdout.
     .filter(event => event.kind === 'stdout')
-    .map(event => event.data && event.data.replace(/\r?\n$/, ''));
+    .map(event => event.data && event.data.replace(/\r*\n$/, ''));
 }
 
 function spawnAdbLogcat(): child_process$ChildProcess {

--- a/pkg/nuclide-adb-logcat/package.json
+++ b/pkg/nuclide-adb-logcat/package.json
@@ -24,7 +24,7 @@
       "whitelistedTags": {
         "title": "Tags to include",
         "description": "Messages that don't have tags that match this pattern will be ignored.",
-        "default": "^(React|ReactNativeJS|ACRA|AndroidRuntime|TTI|BuckReporting|unknown)$",
+        "default": "^((unknown:|)React|ReactNativeJS|ACRA|AndroidRuntime|TTI|BuckReporting|unknown)$",
         "type": "string"
       }
     }


### PR DESCRIPTION
There is an additional CR before CRLF in log lines, which prevents proper parsing of log lines from  adb (version 1.0.36).

Also, some React errors have `unknown:React` tag and will not get parsed using the default configuration:

```
[ 01-26 13:20:34.550  3053: 3053 E/unknown:React ]
Exception in native call
com.facebook.react.devsupport.DebugServerException:
...
```