### PR TITLE
Updated notifyRevisionStatus's success pop-up to be dismissable

### DIFF
--- a/pkg/nuclide-diff-view/lib/utils.js
+++ b/pkg/nuclide-diff-view/lib/utils.js
@@ -519,6 +519,7 @@ function notifyRevisionStatus(
       text: 'Open in Phabricator',
     }],
     nativeFriendly: true,
+    dismissable: true,
   });
 }
 


### PR DESCRIPTION
Added `dismissable: true` to `notifyRevisionStatus` so that Publish to Phabriactor dialog remains until user dismisses it.