### PR TITLE
Fix adb-logcat metadata regex for 5-digit decTID

### DIFF
--- a/pkg/nuclide-adb-logcat/lib/parseLogcatMetadata.js
+++ b/pkg/nuclide-adb-logcat/lib/parseLogcatMetadata.js
@@ -12,7 +12,7 @@ import type {Metadata, Priority} from './types';
 
 // Example: [ 01-14 17:14:44.285   640:  656 E/KernelUidCpuTimeReader ]
 // eslint-disable-next-line max-len
-const METADATA_REGEX = /^\[ (\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3})\s+(\d+):(?:(0x[a-f0-9]+)|\s+(\d+))\s+(V|D|I|W|E|F|S)\/(.+) ]$/;
+const METADATA_REGEX = /^\[ (\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3})\s+(\d+):(?:(0x[a-f0-9]+)|\s*(\d+))\s+(V|D|I|W|E|F|S)\/(.+) ]$/;
 
 export default function parseLogcatMetadata(line: string): ?Metadata {
   const match = line.match(METADATA_REGEX);

--- a/pkg/nuclide-adb-logcat/spec/parseLogcatMetadata-spec.js
+++ b/pkg/nuclide-adb-logcat/spec/parseLogcatMetadata-spec.js
@@ -52,4 +52,12 @@ describe('parseLogcatMetadata', () => {
     invariant(parsed != null);
     expect(parsed.tag).toBe('fb4a(:<default>):PeriodicForegroundScheduler');
   });
+
+  it('parses the 5-digit tid', () => {
+    const parsed = parseLogcatMetadata(
+      '[ 01-28 14:59:27.633  3211:15223 I/ReactNativeJS ]',
+    );
+    invariant(parsed != null);
+    expect(parsed.tid).toBe(15223);
+  });
 });


### PR DESCRIPTION
If decTID is 5-digit (which doesn't happen very often), metadata will not be parsed:
```
[ 01-28 14:59:27.633  3211:15223 I/ReactNativeJS ]
```