### PR TITLE
Diagnostics: Add toggle to show full diagnostic traces

### DIFF
--- a/pkg/nuclide-diagnostics-ui/lib/DiagnosticsPanel.js
+++ b/pkg/nuclide-diagnostics-ui/lib/DiagnosticsPanel.js
@@ -32,6 +32,7 @@ type Props = {
   warnAboutLinter: boolean,
   disableLinter: () => mixed,
   showTraces: boolean,
+  onShowTracesChange: (isChecked: boolean) => mixed,
 };
 
 /**
@@ -42,6 +43,8 @@ export default class DiagnosticsPanel extends React.Component {
 
   constructor(props: mixed) {
     super(props);
+    (this: any)._onShowTracesChange =
+      this._onShowTracesChange.bind(this);
     (this: any)._onFilterByActiveTextEditorChange =
       this._onFilterByActiveTextEditorChange.bind(this);
     (this: any)._openAllFilesWithErrors =
@@ -106,6 +109,13 @@ export default class DiagnosticsPanel extends React.Component {
           <ToolbarRight>
             <span className="inline-block">
               <Checkbox
+                checked={this.props.showTraces}
+                label="Show full diagnostic traces"
+                onChange={this._onShowTracesChange}
+              />
+            </span>
+            <span className="inline-block">
+              <Checkbox
                 checked={this.props.filterByActiveTextEditor}
                 label="Show only diagnostics for current file"
                 onChange={this._onFilterByActiveTextEditorChange}
@@ -128,6 +138,11 @@ export default class DiagnosticsPanel extends React.Component {
         />
       </div>
     );
+  }
+
+  _onShowTracesChange(isChecked: boolean) {
+    track('diagnostics-panel-toggle-show-traces', {isChecked: isChecked.toString()});
+    this.props.onShowTracesChange.call(null, isChecked);
   }
 
   _onFilterByActiveTextEditorChange(isChecked: boolean) {

--- a/pkg/nuclide-diagnostics-ui/lib/DiagnosticsPanelModel.js
+++ b/pkg/nuclide-diagnostics-ui/lib/DiagnosticsPanelModel.js
@@ -47,8 +47,8 @@ export class DiagnosticsPanelModel {
 
   constructor(
     diagnostics: Observable<Array<DiagnosticMessage>>,
-    showTraces: boolean,
-    onShowTracesChange: (isChecked: boolean) => void,
+    showTracesStream: Observable<boolean>,
+    onShowTracesChange: (showTraces: boolean) => void,
     disableLinter: () => void,
     warnAboutLinterStream: Observable<boolean>,
     initialfilterByActiveTextEditor: boolean,
@@ -67,7 +67,7 @@ export class DiagnosticsPanelModel {
       getPropsStream(
         diagnostics,
         warnAboutLinterStream,
-        showTraces,
+        showTracesStream,
         onShowTracesChange,
         disableLinter,
         initialfilterByActiveTextEditor,
@@ -123,8 +123,8 @@ export class DiagnosticsPanelModel {
 function getPropsStream(
   diagnosticsStream: Observable<Array<DiagnosticMessage>>,
   warnAboutLinterStream: Observable<boolean>,
-  initalShowTraces: boolean,
-  onShowTracesChange: (isChecked: boolean) => void,
+  showTracesStream: Observable<boolean>,
+  onShowTracesChange: (showTraces: boolean) => void,
   disableLinter: () => void,
   initialfilterByActiveTextEditor: boolean,
   onFilterByActiveTextEditorChange: (filterByActiveTextEditor: boolean) => void,
@@ -145,12 +145,6 @@ function getPropsStream(
     diagnosticsStream.map(diagnostics => diagnostics.slice().sort(compareMessagesByFile)),
   );
 
-  const showTracesStream = new BehaviorSubject(initalShowTraces);
-  const handleShowTracesStream = (showTraces: boolean) => {
-    showTracesStream.next(showTraces);
-    onShowTracesChange(showTraces);
-  };
-
   const filterByActiveTextEditorStream = new BehaviorSubject(initialfilterByActiveTextEditor);
   const handleFilterByActiveTextEditorChange = (filterByActiveTextEditor: boolean) => {
     filterByActiveTextEditorStream.next(filterByActiveTextEditor);
@@ -169,7 +163,7 @@ function getPropsStream(
       diagnostics,
       warnAboutLinter,
       showTraces: traces,
-      onShowTracesChange: handleShowTracesStream,
+      onShowTracesChange,
       disableLinter,
       filterByActiveTextEditor: filter,
       onFilterByActiveTextEditorChange: handleFilterByActiveTextEditorChange,

--- a/pkg/nuclide-diagnostics-ui/lib/main.js
+++ b/pkg/nuclide-diagnostics-ui/lib/main.js
@@ -135,9 +135,10 @@ class Activation {
         .switchMap(updater => (
           updater == null ? Observable.of([]) : updater.allMessageUpdates
         )),
-      featureConfig.observeAsStream('nuclide-diagnostics-ui.showDiagnosticTraces'),
+      // eslint-disable-next-line max-len
+      ((featureConfig.observeAsStream('nuclide-diagnostics-ui.showDiagnosticTraces'): any): Observable<boolean>),
       showTraces => {
-        featureConfig.set('nuclide-diagnostics-ui.showDiagnosticTraces', showTraces)
+        featureConfig.set('nuclide-diagnostics-ui.showDiagnosticTraces', showTraces);
       },
       disableLinter,
       observeLinterPackageEnabled(),

--- a/pkg/nuclide-diagnostics-ui/lib/main.js
+++ b/pkg/nuclide-diagnostics-ui/lib/main.js
@@ -140,8 +140,6 @@ class Activation {
           updater == null ? Observable.of([]) : updater.allMessageUpdates
         )),
       this._state.showTraces,
-      // https://github.com/gajus/eslint-plugin-flowtype/pull/131
-      // eslint-disable-next-line flowtype/space-after-type-colon
       showTraces => {
         if (this._state != null) {
           this._state.showTraces = showTraces;
@@ -150,8 +148,6 @@ class Activation {
       disableLinter,
       observeLinterPackageEnabled(),
       this._state.filterByActiveTextEditor,
-      // https://github.com/gajus/eslint-plugin-flowtype/pull/131
-      // eslint-disable-next-line flowtype/space-after-type-colon
       filterByActiveTextEditor => {
         if (this._state != null) {
           this._state.filterByActiveTextEditor = filterByActiveTextEditor;

--- a/pkg/nuclide-diagnostics-ui/lib/main.js
+++ b/pkg/nuclide-diagnostics-ui/lib/main.js
@@ -42,7 +42,6 @@ const LINTER_PACKAGE = 'linter';
 const MAX_OPEN_ALL_FILES = 20;
 
 type ActivationState = {
-  showTraces: boolean,
   filterByActiveTextEditor: boolean,
 };
 
@@ -60,11 +59,8 @@ class Activation {
   constructor(state_: ?Object): void {
     this._diagnosticUpdaters = new BehaviorSubject(null);
     this._subscriptions = new UniversalDisposable();
-    const _showDiagnosticTraces: boolean =
-      (featureConfig.get('nuclide-diagnostics-ui.showDiagnosticTraces'): any);
     const state = state_ || {};
     this._state = {
-      showTraces: state.showTraces || _showDiagnosticTraces,
       filterByActiveTextEditor: state.filterByActiveTextEditor === true,
     };
   }
@@ -139,11 +135,9 @@ class Activation {
         .switchMap(updater => (
           updater == null ? Observable.of([]) : updater.allMessageUpdates
         )),
-      this._state.showTraces,
+      featureConfig.observeAsStream('nuclide-diagnostics-ui.showDiagnosticTraces'),
       showTraces => {
-        if (this._state != null) {
-          this._state.showTraces = showTraces;
-        }
+        featureConfig.set('nuclide-diagnostics-ui.showDiagnosticTraces', showTraces)
       },
       disableLinter,
       observeLinterPackageEnabled(),

--- a/pkg/nuclide-diagnostics-ui/lib/main.js
+++ b/pkg/nuclide-diagnostics-ui/lib/main.js
@@ -62,7 +62,7 @@ class Activation {
     this._subscriptions = new UniversalDisposable();
     const state = state_ || {};
     this._state = {
-      showTraces: state.showTraces || this._getShowDiagnosticTraces(),
+      showTraces: state.showTraces || featureConfig.get('nuclide-diagnostics-ui.showDiagnosticTraces'),
       filterByActiveTextEditor: state.filterByActiveTextEditor === true,
     };
   }
@@ -129,10 +129,6 @@ class Activation {
       },
       priority: 4,
     };
-  }
-
-  _getShowDiagnosticTraces(): boolean {
-    return ((featureConfig.get('nuclide-diagnostics-ui.showDiagnosticTraces'): any): boolean);
   }
 
   _createDiagnosticsPanelModel(): DiagnosticsPanelModel {

--- a/pkg/nuclide-diagnostics-ui/lib/main.js
+++ b/pkg/nuclide-diagnostics-ui/lib/main.js
@@ -135,8 +135,8 @@ class Activation {
         .switchMap(updater => (
           updater == null ? Observable.of([]) : updater.allMessageUpdates
         )),
-      // eslint-disable-next-line max-len
-      ((featureConfig.observeAsStream('nuclide-diagnostics-ui.showDiagnosticTraces'): any): Observable<boolean>),
+      ((featureConfig.observeAsStream('nuclide-diagnostics-ui.showDiagnosticTraces'): any):
+        Observable<boolean>),
       showTraces => {
         featureConfig.set('nuclide-diagnostics-ui.showDiagnosticTraces', showTraces);
       },

--- a/pkg/nuclide-diagnostics-ui/lib/main.js
+++ b/pkg/nuclide-diagnostics-ui/lib/main.js
@@ -60,9 +60,11 @@ class Activation {
   constructor(state_: ?Object): void {
     this._diagnosticUpdaters = new BehaviorSubject(null);
     this._subscriptions = new UniversalDisposable();
+    const _showDiagnosticTraces: boolean =
+      (featureConfig.get('nuclide-diagnostics-ui.showDiagnosticTraces'): any);
     const state = state_ || {};
     this._state = {
-      showTraces: state.showTraces || featureConfig.get('nuclide-diagnostics-ui.showDiagnosticTraces'),
+      showTraces: state.showTraces || _showDiagnosticTraces,
       filterByActiveTextEditor: state.filterByActiveTextEditor === true,
     };
   }


### PR DESCRIPTION
@nmote In response to #998 cc @ColinCampbell 

It's common to need more information to debug flow errors. This change reduces the need to open terminal and run ``flow`` and doesn't clutter the interface.

Settings still has a "Show full diagnostic traces" option. It's used as a default value for when the "Diagnostics" view is constructed.

![showinteraction](https://cloud.githubusercontent.com/assets/16157429/22670054/56ac6a0a-ec7c-11e6-85b8-b8184a84507b.gif)
