### PR TITLE
[React Inspector] Bump react-devtools-core

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1838,9 +1838,16 @@
       "resolved": "https://registry.npmjs.org/react-addons-update/-/react-addons-update-15.3.1.tgz"
     },
     "react-devtools-core": {
-      "version": "1.0.6",
-      "from": "react-devtools-core@>=1.0.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-1.0.6.tgz"
+      "version": "2.0.5",
+      "from": "react-devtools-core@2.0.5",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-2.0.5.tgz",
+      "dependencies": {
+        "ws": {
+          "version": "2.0.3",
+          "from": "ws@>=2.0.3 <3.0.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-2.0.3.tgz"
+        }
+      }
     },
     "react-dom": {
       "version": "15.3.1",
@@ -1965,9 +1972,9 @@
       }
     },
     "sax": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "from": "sax@>=0.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz"
     },
     "sb-callsite": {
       "version": "1.1.2",
@@ -2316,9 +2323,9 @@
       }
     },
     "ultron": {
-      "version": "1.0.2",
-      "from": "ultron@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
+      "version": "1.1.0",
+      "from": "ultron@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz"
     },
     "underscore": {
       "version": "1.6.0",
@@ -2452,7 +2459,14 @@
     "ws": {
       "version": "1.1.1",
       "from": "ws@1.1.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
+      "dependencies": {
+        "ultron": {
+          "version": "1.0.2",
+          "from": "ultron@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
+        }
+      }
     },
     "xml2js": {
       "version": "0.4.17",

--- a/npm-shrinkwrap.production.json
+++ b/npm-shrinkwrap.production.json
@@ -951,9 +951,16 @@
       "resolved": "https://registry.npmjs.org/react-addons-update/-/react-addons-update-15.3.1.tgz"
     },
     "react-devtools-core": {
-      "version": "1.0.6",
-      "from": "react-devtools-core@>=1.0.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-1.0.6.tgz"
+      "version": "2.0.5",
+      "from": "react-devtools-core@2.0.5",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-2.0.5.tgz",
+      "dependencies": {
+        "ws": {
+          "version": "2.0.3",
+          "from": "ws@>=2.0.3 <3.0.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-2.0.3.tgz"
+        }
+      }
     },
     "react-dom": {
       "version": "15.3.1",
@@ -996,9 +1003,9 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.0.1.tgz"
     },
     "sax": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "from": "sax@>=0.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz"
     },
     "sb-callsite": {
       "version": "1.1.2",
@@ -1171,9 +1178,9 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.12.tgz"
     },
     "ultron": {
-      "version": "1.0.2",
-      "from": "ultron@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
+      "version": "1.1.0",
+      "from": "ultron@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz"
     },
     "underscore": {
       "version": "1.6.0",
@@ -1243,7 +1250,14 @@
     "ws": {
       "version": "1.1.1",
       "from": "ws@1.1.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
+      "dependencies": {
+        "ultron": {
+          "version": "1.0.2",
+          "from": "ultron@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
+        }
+      }
     },
     "xml2js": {
       "version": "0.4.17",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "nullthrows": "1.0.0",
     "plist": "2.0.1",
     "react": "15.3.1",
-    "react-devtools-core": "1.0.6",
+    "react-devtools-core": "2.0.5",
     "react-dom": "15.3.1",
     "react-for-atom": "15.3.1-0",
     "redux": "3.6.0",


### PR DESCRIPTION
Follow up to #1016.
Changes:

* Bumps `ws` dependency to 2.0 as [requested](https://github.com/facebook/nuclide/pull/1016#issuecomment-278046379).
* Adds support for the new DevTools injection mechanism that will very soon replace the current one in RN master (more details in https://github.com/facebook/react-devtools/issues/489).

Despite 2.0 bump this is backwards compatible for Nuclide (there were other changes it doesn't rely on).

Note that you can't test the change on Inspector with master of RN because the integration was recently temporarily disabled. However I tested it both with RN stable (works) and with pending changes I'm about to make to RN (also works).