### PR TITLE
Upgrade to latest package-deps

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -275,7 +275,7 @@ export function activate() {
     const firstWindowId = remote.BrowserWindow.getAllWindows()[0].id;
     const currentWindowId = remote.getCurrentWindow().id;
     if (firstWindowId === currentWindowId) {
-      atomPackageDepsInstall('nuclide');
+      atomPackageDepsInstall('nuclide', true);
     }
   }
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -53,16 +53,6 @@ atom.deserializers.add({
 
 // Exported "config" object
 export const config = {
-  installRecommendedPackages: {
-    default: false,
-    description:
-      'On start up, check for and install Atom packages recommended for use with Nuclide. The'
-      + ' list of packages can be found in the <code>package-deps</code> setting in this package\'s'
-      + ' "package.json" file. Disabling this setting will not uninstall packages it previously'
-      + ' installed. Restart Atom after changing this setting for it to take effect.',
-    title: 'Install Recommended Packages on Startup',
-    type: 'boolean',
-  },
   useLocalRpc: {
     default: false,
     description:
@@ -268,7 +258,7 @@ export function activate() {
   // Install public, 3rd-party Atom packages listed in this package's 'package-deps' setting. Run
   // this *after* other packages are activated so they can modify this setting if desired before
   // installation is attempted.
-  if (featureConfig.get('installRecommendedPackages')) {
+  if (!atom.inSpecMode()) {
     // Workaround for restoring multiple Atom windows. This prevents having all
     // the windows trying to install the deps at the same time - often clobbering
     // each other's install.

--- a/lib/main.js
+++ b/lib/main.js
@@ -22,7 +22,6 @@
 
 import './preload-dependencies';
 
-import featureConfig from '../pkg/commons-atom/featureConfig';
 import fs from 'fs';
 import invariant from 'assert';
 // eslint-disable-next-line nuclide-internal/prefer-nuclide-uri

--- a/lib/test-runner.js
+++ b/lib/test-runner.js
@@ -60,11 +60,6 @@ export default async function(params: TestRunnerParams): Promise<ExitCode> {
           }
           // `atom.confirm` blocks Atom and stops the integration tests.
           spyOn(atomGlobal, 'confirm');
-          // Ensure 3rd-party packages are not installed via the
-          // 'atom-package-deps' package when the 'nuclide' package is activated.
-          // They are assumed to be already in ~/.atom/packages. js_test_runner.py
-          // handles installing them during automated testing.
-          atomGlobal.config.set('nuclide.installRecommendedPackages', false);
         });
 
         jasmine.getEnv().afterEach(() => {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "adm-zip": "0.4.7",
     "async-to-generator": "1.0.0",
-    "atom-package-deps": "4.3.1",
+    "atom-package-deps": "4.4.1",
     "babylon": "6.15.0",
     "bplist-parser": "0.1.1",
     "chalk": "1.1.3",


### PR DESCRIPTION
This PR

 - Upgrades to latest `atom-package-deps` version
 - Removes a config that is no longer necessary after the latest version of the package

You can see the new Confirmation Dialog in action in [`atom-package-deps` Screenshots](https://github.com/steelbrain/package-deps#screenshots)