### PR TITLE
Fix common which function for Windows

### DIFF
--- a/pkg/commons-node/which.js
+++ b/pkg/commons-node/which.js
@@ -10,6 +10,7 @@
 
 import {checkOutput} from './process';
 import os from 'os';
+import nuclideUri from './nuclideUri';
 
 /**
  * Provides a cross-platform way to check whether a binary is available.
@@ -17,10 +18,12 @@ import os from 'os';
  * We ran into problems with the npm `which` package (the nature of which I unfortunately don't
  * remember) so we can use this for now.
  */
-export default async function which(command: string): Promise<?string> {
-  const whichCommand = process.platform === 'win32' ? 'where' : 'which';
+export default async function which(path: string): Promise<?string> {
+  const isWindows = process.platform === 'win32';
+  const whichCommand = isWindows ? 'where' : 'which';
+  const searchPath = isWindows ? `${nuclideUri.dirname(path)}:${nuclideUri.basename(path)}` : path;
   try {
-    const result = await checkOutput(whichCommand, [command]);
+    const result = await checkOutput(whichCommand, [searchPath]);
     return result.stdout.split(os.EOL)[0];
   } catch (e) {
     return null;


### PR DESCRIPTION
This should fix #728 and #983 for Windows, where Flow type checking does not work because the `which` function to find its binary is broken. Based on @scottrangerio's gist at https://github.com/facebook/nuclide/issues/983#issuecomment-277526290 but using the more robust `basename()`, `dirname()` path functions instead of an array split.