### PR TITLE
Respect encoding on remote connection

### DIFF
--- a/pkg/nuclide-remote-connection/lib/RemoteFile.js
+++ b/pkg/nuclide-remote-connection/lib/RemoteFile.js
@@ -254,10 +254,11 @@ export class RemoteFile {
   }
 
   async read(flushCache?: boolean): Promise<string> {
-    const data = await this._getFileSystemService().readFile(this._localPath);
+    const encoding = this.getEncoding();
+    const options = encoding ? {encoding} : {};
+    const data = await this._getFileSystemService().readFile(this._localPath, options);
     const contents = data.toString();
     this._setDigest(contents);
-    // TODO: respect encoding
     return contents;
   }
 
@@ -267,7 +268,9 @@ export class RemoteFile {
 
   async write(text: string): Promise<void> {
     const previouslyExisted = await this.exists();
-    await this._getFileSystemService().writeFile(this._localPath, text);
+    const encoding = this.getEncoding();
+    const options = encoding ? {encoding} : {};
+    await this._getFileSystemService().writeFile(this._localPath, text, options);
     if (!previouslyExisted && this._subscriptionCount > 0) {
       this._subscribeToNativeChangeEvents();
     }

--- a/pkg/nuclide-server/lib/services/FileSystemService.js
+++ b/pkg/nuclide-server/lib/services/FileSystemService.js
@@ -255,11 +255,21 @@ export function unlink(path: string): Promise<void> {
  */
 export async function readFile(
   path: string,
-  options?: {flag?: string},
+  options?: {encoding?: string, flag?: string},
 ): Promise<Buffer> {
   const stats = await fsPromise.stat(path);
   if (stats.size > READFILE_SIZE_LIMIT) {
     throw new Error(`File is too large (${stats.size} bytes)`);
+  }
+  if (options && options.encoding) {
+    const encoding = options.encoding;
+    delete options.encoding;
+    if (encoding !== 'utf8') {
+      const iconv = require('iconv-lite');
+      return fsPromise.readFile(path, options)
+        .then(buffer => iconv.decode(buffer, encoding))
+        .then(text => new Buffer(text));
+    }
   }
   return fsPromise.readFile(path, options);
 }
@@ -314,7 +324,14 @@ export async function writeFile(path: string, data: string,
   let complete = false;
   const tempFilePath = await fsPromise.tempfile('nuclide');
   try {
-    await fsPromise.writeFile(tempFilePath, data, options);
+    if (options && options.encoding && options.encoding !== 'utf8') {
+      const iconv = require('iconv-lite');
+      const encodedData = iconv.encode(data, options.encoding);
+      delete options.encoding;
+      await fsPromise.writeFile(tempFilePath, encodedData, options);
+    } else {
+      await fsPromise.writeFile(tempFilePath, data, options);
+    }
 
     // Expand the target path in case it contains symlinks.
     let realPath = path;


### PR DESCRIPTION
Read/Write on remote connection works correctly only for files which encoding is `UTF-8`.
This PR fixes this.
