### PR TITLE
Right-align line number column in diagnostics pane table

### DIFF
--- a/pkg/nuclide-diagnostics-ui/styles/diagnostics-table.less
+++ b/pkg/nuclide-diagnostics-ui/styles/diagnostics-table.less
@@ -19,6 +19,11 @@
     th:last-child {
       border-right-width: 0;
     }
+
+    .nuclide-ui-table-body-cell:nth-child(4),
+    .nuclide-ui-table-header-cell:nth-child(4) {
+      text-align: right;
+    }
   }
 }
 


### PR DESCRIPTION
Looks like this after the change

![image](https://cloud.githubusercontent.com/assets/118951/24769264/bb56088c-1aba-11e7-90cf-3fb3ee4b1b65.png)
