### PR TITLE
Fix diagnostics view aligning description column right in some cases

### DIFF
--- a/pkg/nuclide-debugger-base/lib/types.js
+++ b/pkg/nuclide-debugger-base/lib/types.js
@@ -23,4 +23,5 @@ export type ThreadColumn = {
   // Optional React component for rendering cell contents.
   // The component receives the cell value via `props.data`.
   component?: any,
+  textAlignRight?: boolean,
 };

--- a/pkg/nuclide-diagnostics-ui/lib/DiagnosticsPane.js
+++ b/pkg/nuclide-diagnostics-ui/lib/DiagnosticsPane.js
@@ -178,6 +178,7 @@ export default class DiagnosticsPane extends React.Component {
         key: 'range',
         title: 'Line',
         width: 0.05,
+        textAlignRight: true,
       },
       {
         component: DescriptionComponent,

--- a/pkg/nuclide-diagnostics-ui/styles/diagnostics-table.less
+++ b/pkg/nuclide-diagnostics-ui/styles/diagnostics-table.less
@@ -20,8 +20,7 @@
       border-right-width: 0;
     }
 
-    .nuclide-ui-table-body-cell:nth-child(4),
-    .nuclide-ui-table-header-cell:nth-child(4) {
+    .cell-text-align-right {
       text-align: right;
     }
   }

--- a/pkg/nuclide-ui/Table.js
+++ b/pkg/nuclide-ui/Table.js
@@ -27,6 +27,7 @@ export type Column = {
   // Optional React component for rendering cell contents.
   // The component receives the cell value via `props.data`.
   component?: ReactClass<any>,
+  textAlignRight?: boolean,
 };
 export type Row = {
   +className?: string,
@@ -282,6 +283,7 @@ export class Table extends React.Component {
       const {
         title,
         key,
+        textAlignRight,
       } = column;
       const resizeHandle = i === columns.length - 1
         ? null
@@ -317,6 +319,7 @@ export class Table extends React.Component {
           className={classnames({
             'nuclide-ui-table-header-cell': true,
             'nuclide-ui-table-header-cell-sortable': sortable,
+            'cell-text-align-right': textAlignRight,
           })}
           title={titleOverlay}
           key={key}
@@ -336,6 +339,7 @@ export class Table extends React.Component {
         const {
           key,
           component: Component,
+          textAlignRight,
         } = column;
         let datum = data[key];
         if (Component != null) {
@@ -350,7 +354,10 @@ export class Table extends React.Component {
         }
         return (
           <div
-            className="nuclide-ui-table-body-cell"
+            className={classnames({
+              'nuclide-ui-table-body-cell': true,
+              'cell-text-align-right': textAlignRight,
+            })}
             key={j}
             style={cellStyle}
             title={datum != null ? String(datum) : null}>


### PR DESCRIPTION
Related issue: https://github.com/facebook/nuclide/issues/1098.

Basically this PR:
* Adds an optional field that whether a certain column should align text right
* Changed the css rule for line-number to use the optional field, instead of assuming it's always the fourth column.
