### PR TITLE
Add a 'kind' property to allow the UI to be easily themed by kind

### DIFF
--- a/pkg/nuclide-outline-view/lib/OutlineView.js
+++ b/pkg/nuclide-outline-view/lib/OutlineView.js
@@ -173,7 +173,7 @@ class OutlineTree extends React.PureComponent {
       }
     };
 
-    const classNames = [ 'list-nested-item' ];
+    const classNames = ['list-nested-item'];
     if (outline.kind) {
       classNames.push(`kind-${outline.kind}`);
     }

--- a/pkg/nuclide-outline-view/lib/OutlineView.js
+++ b/pkg/nuclide-outline-view/lib/OutlineView.js
@@ -173,7 +173,11 @@ class OutlineTree extends React.PureComponent {
       }
     };
 
-    const classes = classnames('list-nested-item', {
+    const classNames = [ 'list-nested-item' ];
+    if (outline.kind) {
+      classNames.push(`kind-${outline.kind}`);
+    }
+    const classes = classnames(classNames, {
       selected: outline.highlighted,
     });
     return (

--- a/pkg/nuclide-outline-view/lib/createOutlines.js
+++ b/pkg/nuclide-outline-view/lib/createOutlines.js
@@ -93,7 +93,7 @@ function treeToUiTree(
   const shortName = nameOnly && outlineTree.representativeName != null;
   return {
     icon: nameOnly ? undefined : outlineTree.icon,
-    kind: outlineTree.kind,
+    kind: nameOnly ? undefined : outlineTree.kind,
     plainText: shortName
       ? outlineTree.representativeName
       : outlineTree.plainText,

--- a/pkg/nuclide-outline-view/lib/createOutlines.js
+++ b/pkg/nuclide-outline-view/lib/createOutlines.js
@@ -93,6 +93,7 @@ function treeToUiTree(
   const shortName = nameOnly && outlineTree.representativeName != null;
   return {
     icon: nameOnly ? undefined : outlineTree.icon,
+    kind: outlineTree.kind,
     plainText: shortName
       ? outlineTree.representativeName
       : outlineTree.plainText,

--- a/pkg/nuclide-outline-view/lib/main.js
+++ b/pkg/nuclide-outline-view/lib/main.js
@@ -41,27 +41,6 @@ export type OutlineTreeForUi = {
   highlighted: boolean,
 };
 
-// Kind of outline tree - matches the names from the Language Server Protocol v2.
-export type OutlineTreeKind =
-  | 'file'
-  | 'module'
-  | 'namespace'
-  | 'package'
-  | 'class'
-  | 'method'
-  | 'property'
-  | 'field'
-  | 'constructor'
-  | 'enum'
-  | 'interface'
-  | 'function'
-  | 'variable'
-  | 'constant'
-  | 'string'
-  | 'number'
-  | 'boolean'
-  | 'array';
-
 /**
  * Includes additional information that is useful to the UI, but redundant or nonsensical for
  * providers to include in their responses.

--- a/pkg/nuclide-outline-view/lib/main.js
+++ b/pkg/nuclide-outline-view/lib/main.js
@@ -27,11 +27,11 @@ import {createOutlines} from './createOutlines';
 import {Observable} from 'rxjs';
 
 import type {TokenizedText} from '../../commons-node/tokenizedText-rpc-types';
-import type {Outline} from './rpc-types';
+import type {Outline, OutlineTreeKind} from './rpc-types';
 
 export type OutlineTreeForUi = {
   icon?: string, // from atom$Octicon, but we use string for convenience of remoting
-  kind?: string, // kind you can pass to the UI for theming, from OutlineTreeKind
+  kind?: OutlineTreeKind, // kind you can pass to the UI for theming
   plainText?: string,
   tokenizedText?: TokenizedText,
 

--- a/pkg/nuclide-outline-view/lib/main.js
+++ b/pkg/nuclide-outline-view/lib/main.js
@@ -43,9 +43,24 @@ export type OutlineTreeForUi = {
 
 // Kind of outline tree - matches the names from the Language Server Protocol v2.
 export type OutlineTreeKind =
-  'file' | 'module' | 'namespace' | 'package' | 'class' | 'method' | 'property' | 'field' |
-  'constructor' | 'enum' | 'interface' | 'function' | 'variable' | 'constant' | 'string' |
-  'number' | 'boolean' | 'array';
+  | 'file'
+  | 'module'
+  | 'namespace'
+  | 'package'
+  | 'class'
+  | 'method'
+  | 'property'
+  | 'field'
+  | 'constructor'
+  | 'enum'
+  | 'interface'
+  | 'function'
+  | 'variable'
+  | 'constant'
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'array';
 
 /**
  * Includes additional information that is useful to the UI, but redundant or nonsensical for

--- a/pkg/nuclide-outline-view/lib/main.js
+++ b/pkg/nuclide-outline-view/lib/main.js
@@ -31,7 +31,7 @@ import type {Outline} from './rpc-types';
 
 export type OutlineTreeForUi = {
   icon?: string, // from atom$Octicon, but we use string for convenience of remoting
-  kind?: string, // a kind you can pass to the UI for theming
+  kind?: string, // kind you can pass to the UI for theming, from OutlineTreeKind
   plainText?: string,
   tokenizedText?: TokenizedText,
 
@@ -40,6 +40,12 @@ export type OutlineTreeForUi = {
   children: Array<OutlineTreeForUi>,
   highlighted: boolean,
 };
+
+// Kind of outline tree - matches the names from the Language Server Protocol v2.
+export type OutlineTreeKind =
+  'file' | 'module' | 'namespace' | 'package' | 'class' | 'method' | 'property' | 'field' |
+  'constructor' | 'enum' | 'interface' | 'function' | 'variable' | 'constant' | 'string' |
+  'number' | 'boolean' | 'array';
 
 /**
  * Includes additional information that is useful to the UI, but redundant or nonsensical for

--- a/pkg/nuclide-outline-view/lib/main.js
+++ b/pkg/nuclide-outline-view/lib/main.js
@@ -31,6 +31,7 @@ import type {Outline} from './rpc-types';
 
 export type OutlineTreeForUi = {
   icon?: string, // from atom$Octicon, but we use string for convenience of remoting
+  kind?: string, // a kind you can pass to the UI for theming
   plainText?: string,
   tokenizedText?: TokenizedText,
 

--- a/pkg/nuclide-outline-view/lib/rpc-types.js
+++ b/pkg/nuclide-outline-view/lib/rpc-types.js
@@ -13,7 +13,7 @@ import type {TokenizedText} from '../../commons-node/tokenizedText-rpc-types';
 
 export type OutlineTree = {
   icon?: string, // from atom$Octicon (that type's not allowed over rpc so we use string)
-  kind?: string, // kind you can pass to the UI for theming, from OutlineTreeKind
+  kind?: OutlineTreeKind, // kind you can pass to the UI for theming, from OutlineTreeKind
 
   // Must be one or the other. If both are present, tokenizedText is preferred.
   plainText?: string,

--- a/pkg/nuclide-outline-view/lib/rpc-types.js
+++ b/pkg/nuclide-outline-view/lib/rpc-types.js
@@ -13,7 +13,7 @@ import type {TokenizedText} from '../../commons-node/tokenizedText-rpc-types';
 
 export type OutlineTree = {
   icon?: string, // from atom$Octicon (that type's not allowed over rpc so we use string)
-  kind?: string, // a kind you can pass to the UI for theming
+  kind?: string, // kind you can pass to the UI for theming, from OutlineTreeKind
 
   // Must be one or the other. If both are present, tokenizedText is preferred.
   plainText?: string,
@@ -28,3 +28,24 @@ export type OutlineTree = {
 export type Outline = {
   outlineTrees: Array<OutlineTree>,
 };
+
+// Kind of outline tree - matches the names from the Language Server Protocol v2.
+export type OutlineTreeKind =
+  | 'file'
+  | 'module'
+  | 'namespace'
+  | 'package'
+  | 'class'
+  | 'method'
+  | 'property'
+  | 'field'
+  | 'constructor'
+  | 'enum'
+  | 'interface'
+  | 'function'
+  | 'variable'
+  | 'constant'
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'array';

--- a/pkg/nuclide-outline-view/lib/rpc-types.js
+++ b/pkg/nuclide-outline-view/lib/rpc-types.js
@@ -13,7 +13,7 @@ import type {TokenizedText} from '../../commons-node/tokenizedText-rpc-types';
 
 export type OutlineTree = {
   icon?: string, // from atom$Octicon (that type's not allowed over rpc so we use string)
-  kind?: OutlineTreeKind, // kind you can pass to the UI for theming, from OutlineTreeKind
+  kind?: OutlineTreeKind, // kind you can pass to the UI for theming
 
   // Must be one or the other. If both are present, tokenizedText is preferred.
   plainText?: string,

--- a/pkg/nuclide-outline-view/lib/rpc-types.js
+++ b/pkg/nuclide-outline-view/lib/rpc-types.js
@@ -13,6 +13,7 @@ import type {TokenizedText} from '../../commons-node/tokenizedText-rpc-types';
 
 export type OutlineTree = {
   icon?: string, // from atom$Octicon (that type's not allowed over rpc so we use string)
+  kind?: string, // a kind you can pass to the UI for theming
 
   // Must be one or the other. If both are present, tokenizedText is preferred.
   plainText?: string,


### PR DESCRIPTION
This PR adds a kind property that can be set by the underling provider that bubbles up to the ui as a `kind-${outline.kind}` up on the `<li>` for the item, e.g.

![image](https://cloud.githubusercontent.com/assets/118951/25599321/1abb8aac-2e90-11e7-8e79-24f5b0525e8c.png)

Does not interfere with the current icon property/visualization (although could be overridden by a theme)