### PR TITLE
fix minor typo

### DIFF
--- a/docs/_docs/help/troubleshooting.md
+++ b/docs/_docs/help/troubleshooting.md
@@ -83,7 +83,7 @@ sudo chown -R userid:userid .npm
 where `userid` is your userid.  If you still get errors you may need to clear your NPM cache with:
 
 ```bash
-npm clear cache
+npm cache clear
 ```
 
 ### Files Not Syncing


### PR DESCRIPTION
According to https://docs.npmjs.com/cli/cache, the correct is `npm cache clear`, not `npm clear cache`.