### PR TITLE
Accomodate changes in text-editor-component refactor

### DIFF
--- a/flow-libs/atom.js.flow
+++ b/flow-libs/atom.js.flow
@@ -954,6 +954,7 @@ declare class atom$TextEditorComponent {
   domNode: HTMLElement,
   scrollViewNode: HTMLElement,
   presenter: atom$TextEditorPresenter,
+  refs: atom$TextEditorComponentRefs,
   linesComponent: atom$LinesComponent,
   pixelPositionForScreenPosition(
     screenPosition: atom$Point,
@@ -984,6 +985,14 @@ declare class atom$TextEditorPresenter {
 declare class atom$LinesComponent {
   domNode: HTMLElement,
   getDomNode(): HTMLElement,
+}
+
+/**
+ * This is not part of the official Atom 1.0 API. Nevertheless, we need it to access
+ * the deepest dom element receiving DOM events.
+ */
+declare class atom$TextEditorComponentRefs {
+  lineTiles: HTMLElement,
 }
 
 /**

--- a/flow-libs/atom.js.flow
+++ b/flow-libs/atom.js.flow
@@ -956,6 +956,8 @@ declare class atom$TextEditorComponent {
   presenter: atom$TextEditorPresenter,
   refs: atom$TextEditorComponentRefs,
   linesComponent: atom$LinesComponent,
+  startCursorBlinking: () => void,
+  stopCursorBlinking(): void,
   pixelPositionForScreenPosition(
     screenPosition: atom$Point,
     clip?: boolean,

--- a/modules/atom-ide-ui/pkg/hyperclick/lib/HyperclickForTextEditor.js
+++ b/modules/atom-ide-ui/pkg/hyperclick/lib/HyperclickForTextEditor.js
@@ -105,18 +105,32 @@ export default class HyperclickForTextEditor {
     const getLinesDomNode = (): HTMLElement => {
       const {component} = this._textEditorView;
       invariant(component);
-      return component.linesComponent.getDomNode();
+      if (component.refs) {
+        return component.refs.lineTiles;
+      } else {
+        return component.linesComponent.getDomNode();
+      }
     };
     const removeMouseListeners = () => {
       if (this._textEditorView.component == null) {
         return;
       }
-      getLinesDomNode().removeEventListener('mousedown', this._onMouseDown);
-      getLinesDomNode().removeEventListener('mousemove', this._onMouseMove);
+      const linesDomNode = getLinesDomNode();
+      if (!linesDomNode) {
+        return;
+      }
+      linesDomNode.removeEventListener('mousedown', this._onMouseDown);
+      linesDomNode.removeEventListener('mousemove', this._onMouseMove);
     };
     const addMouseListeners = () => {
-      getLinesDomNode().addEventListener('mousedown', this._onMouseDown);
-      getLinesDomNode().addEventListener('mousemove', this._onMouseMove);
+      const {component} = this._textEditorView;
+      invariant(component);
+      const linesDomNode = getLinesDomNode();
+      if (!linesDomNode) {
+        return;
+      }
+      linesDomNode.addEventListener('mousedown', this._onMouseDown);
+      linesDomNode.addEventListener('mousemove', this._onMouseMove);
     };
     this._subscriptions.add(new Disposable(removeMouseListeners));
     this._subscriptions.add(

--- a/modules/atom-ide-ui/pkg/hyperclick/styles/hyperclick.less
+++ b/modules/atom-ide-ui/pkg/hyperclick/styles/hyperclick.less
@@ -1,10 +1,10 @@
 @import "syntax-variables";
 
-atom-text-editor .editor-contents--private .highlight.hyperclick > .region {
+atom-text-editor .lines .highlight.hyperclick > .region {
   border-bottom: 1px solid @syntax-text-color;
 }
 
-atom-text-editor:not([mini]).hyperclick .editor-contents--private {
+atom-text-editor:not([mini]).hyperclick .lines {
   /**
    * Unfortunately, this cannot be a property of `.hyperclick .region`:
    * https://discuss.atom.io/t/some-css-styles-not-honored-by-decorations/11662
@@ -12,7 +12,7 @@ atom-text-editor:not([mini]).hyperclick .editor-contents--private {
   cursor: pointer;
 }
 
-atom-text-editor:not([mini]).hyperclick-loading .editor-contents--private {
+atom-text-editor:not([mini]).hyperclick-loading .lines {
   cursor: wait;
 }
 

--- a/modules/nuclide-commons-ui/AtomTextEditor.js
+++ b/modules/nuclide-commons-ui/AtomTextEditor.js
@@ -211,12 +211,20 @@ export class AtomTextEditor extends React.Component {
     }
     // TODO(most): t9929679 Remove this hack when Atom has a blinking cursor configuration API.
     const {component} = this.getElement();
-    if (component == null) {
+    if (!component) {
       return;
     }
-    const {presenter} = component;
-    presenter.startBlinkingCursors = doNothing;
-    presenter.stopBlinkingCursors(false);
+    if (component.startCursorBlinking) {
+      component.startCursorBlinking = doNothing;
+      component.stopCursorBlinking();
+    } else {
+      const {presenter} = component;
+      if (!presenter) {
+        return;
+      }
+      presenter.startBlinkingCursors = doNothing;
+      presenter.stopBlinkingCursors(false);
+    }
   }
 
   _updateDisabledState(isDisabled: boolean): void {


### PR DESCRIPTION
In https://github.com/atom/atom/pull/12696, significant changes were made to the composition of the text-editor-component. These changes break Nuclide when working against current Atom `master`.

This PR allows Hyperclick to correctly function with the text-editor-component changes. It also fixes an issue with logic used to suppress cursor blinking for read only text editors.

- Fixes https://github.com/facebook/nuclide/issues/1154