### PR TITLE
Bump modules/ to 0.1.4

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
   "packages": [
     "modules/*"
   ],
-  "version": "0.1.1"
+  "version": "0.1.4"
 }

--- a/modules/atom-ide-ui/package.json
+++ b/modules/atom-ide-ui/package.json
@@ -1,13 +1,13 @@
 {
   "name": "atom-ide-ui",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "description": "A suite of language service UIs for Atom.",
   "license": "SEE LICENSE IN LICENSE",
   "main": "./index-entry.js",
   "homepage": "https://nuclide.io/",
   "repository": "https://github.com/facebook/nuclide",
   "scripts": {
-    "prepublishOnly": "../../scripts/release-transpile.js --overwrite .",
+    "prepublish": "../../scripts/modules-prepublish.sh",
     "test": "scripts/test.js"
   },
   "engines": {
@@ -17,9 +17,9 @@
     "async-to-generator": "1.0.0",
     "classnames": "2.2.5",
     "log4js": "1.1.1",
-    "nuclide-commons": "0.1.1",
-    "nuclide-commons-atom": "0.1.1",
-    "nuclide-commons-ui": "0.1.1",
+    "nuclide-commons": "0.1.4",
+    "nuclide-commons-atom": "0.1.4",
+    "nuclide-commons-ui": "0.1.4",
     "react": "15.3.1",
     "react-dom": "15.3.1",
     "rxjs": "5.3.1"

--- a/modules/nuclide-commons-atom/package.json
+++ b/modules/nuclide-commons-atom/package.json
@@ -1,19 +1,19 @@
 {
   "name": "nuclide-commons-atom",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "description": "Common Nuclide node modules (for use with Atom only).",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://nuclide.io/",
   "repository": "https://github.com/facebook/nuclide",
   "scripts": {
-    "prepublishOnly": "../../scripts/release-transpile.js --overwrite .",
+    "prepublish": "../../scripts/modules-prepublish.sh",
     "test": "atom --dev --test spec"
   },
   "atomTestRunner": "../../lib/test-runner-entry.js",
   "dependencies": {
     "async-to-generator": "1.0.0",
     "log4js": "1.1.1",
-    "nuclide-commons": "0.1.1",
+    "nuclide-commons": "0.1.4",
     "rxjs": "5.3.1",
     "semver": "5.3.0"
   }

--- a/modules/nuclide-commons-ui/package.json
+++ b/modules/nuclide-commons-ui/package.json
@@ -1,20 +1,20 @@
 {
   "name": "nuclide-commons-ui",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "description": "Common Nuclide UI components.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://nuclide.io/",
   "repository": "https://github.com/facebook/nuclide",
   "scripts": {
-    "prepublishOnly": "../../scripts/release-transpile.js --overwrite .",
+    "prepublish": "../../scripts/modules-prepublish.sh",
     "test": "atom --dev --test spec"
   },
   "atomTestRunner": "../../lib/test-runner-entry.js",
   "dependencies": {
     "async-to-generator": "1.0.0",
     "classnames": "2.2.5",
-    "nuclide-commons": "0.1.1",
-    "nuclide-commons-atom": "0.1.1",
+    "nuclide-commons": "0.1.4",
+    "nuclide-commons-atom": "0.1.4",
     "react": "15.3.1",
     "react-dom": "15.3.1",
     "rxjs": "5.3.1"

--- a/modules/nuclide-commons/package.json
+++ b/modules/nuclide-commons/package.json
@@ -1,12 +1,12 @@
 {
   "name": "nuclide-commons",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "description": "Common Nuclide node modules.",
   "license": "SEE LICENSE IN LICENSE",
   "homepage": "https://nuclide.io/",
   "repository": "https://github.com/facebook/nuclide",
   "scripts": {
-    "prepublishOnly": "../../scripts/modules-prepublish.sh",
+    "prepublish": "../../scripts/modules-prepublish.sh",
     "test": "node ../../pkg/nuclide-jasmine/bin/jasmine-node-transpiled spec"
   },
   "dependencies": {

--- a/scripts/modules-prepublish.sh
+++ b/scripts/modules-prepublish.sh
@@ -14,8 +14,7 @@ CALLING_DIR="$(pwd -P)"
 echo "Module prepublish: making copies for flow (1 / 2)..."
 find "$CALLING_DIR" \
   -name '*.js' \
-  -not -path '*/spec*' |
-    while read -r filepath; do cp "$filepath" "$filepath.flow"; done
+  -not -path '*/spec*' -exec cp -n {} {}.flow \;
 
 echo "Module prepublish: compiling source (2 / 2) ..."
 "$OWN_DIR/release-transpile.js" --overwrite "$CALLING_DIR"


### PR DESCRIPTION
I had to struggle a bit to get this to publish correctly :O But it works now!

- `prepublishOnly` seems bugged - it doesn't actually wait for the script to finish before publishing (but runs it anyway). Just use plain old `prepublish` for now.
- Switch all modules to use the common prepublish script.
- Make the prepublish script ignore existing flow files (for `atom-ide-ui/index-entry.js.flow`)

Unfortunately I don't think anyone can really use the published flow types until we also start publishing our `flow-libs`.. so we should do that :)

How to repro the publish:

- `lerna publish --exact --skip-git --skip-npm` -> choose a version
- commit & import & land
- `lerna publish --exact --skip-git --repo-version <version>`