### PR TITLE
Add openExternal setting

### DIFF
--- a/modules/atom-ide-ui/pkg/hyperclick/README.md
+++ b/modules/atom-ide-ui/pkg/hyperclick/README.md
@@ -57,7 +57,7 @@ export function getProvider() {
         // The range(s) to underline as a visual cue for clicking.
         range,
         // The function to call when the underlined text is clicked.
-        callback() {},
+        callback(openExternal) {},
       };
     },
   };
@@ -99,6 +99,12 @@ The methods return a suggestion or a `Promise` that resolves to a suggestion:
     - `title`: A string to present in the UI for the user to select.
     - `rightLabel`(optional): An indicator denoting the "kind" of suggestion this represents
     - `callback`: The function to call when the user selects this object.
+  
+    The `callback` is passed the `atom.config.hyperclick.openExternal` setting,
+    which is either `true` or `false`, and can be implemented with [`openExternal`] or [`atom.workspace.open`] respectively.
+
+    [`openExternal`]: https://electron.atom.io/docs/api/shell/#shellopenexternalurl-options-callback
+    [`atom.workspace.open`]: https://atom.io/docs/api/v1.18.0/Workspace#instance-open
 
 Additional provider fields:
 

--- a/modules/atom-ide-ui/pkg/hyperclick/lib/HyperclickForTextEditor.js
+++ b/modules/atom-ide-ui/pkg/hyperclick/lib/HyperclickForTextEditor.js
@@ -148,7 +148,8 @@ export default class HyperclickForTextEditor {
       this._hyperclick.showSuggestionList(this._textEditor, suggestion);
     } else {
       invariant(typeof suggestion.callback === 'function');
-      suggestion.callback();
+      const openExternal = atom.config.get('hyperclick.openExternal');
+      suggestion.callback(openExternal);
     }
   }
 

--- a/modules/atom-ide-ui/pkg/hyperclick/lib/SuggestionListElement.js
+++ b/modules/atom-ide-ui/pkg/hyperclick/lib/SuggestionListElement.js
@@ -175,7 +175,8 @@ class SuggestionList extends React.Component {
   }
 
   _confirm() {
-    this._items[this.state.selectedIndex].callback();
+    const openExternal = atom.config.get('hyperclick.openExternal');
+    this._items[this.state.selectedIndex].callback(openExternal);
     this._close();
   }
 

--- a/modules/atom-ide-ui/pkg/hyperclick/package.json
+++ b/modules/atom-ide-ui/pkg/hyperclick/package.json
@@ -197,6 +197,11 @@
           "description": "meta + click"
         }
       ]
+    },
+    "openExternal": {
+      "description": "Open clicked links in your default browser, or within Atom.",
+      "type": "boolean",
+      "default": true
     }
   },
   "consumedServices": {


### PR DESCRIPTION
Allow users to set globally whether links are opened externally (the default) or indicate that links should be opened within Atom.