### PR TITLE
Print exact object types with | on correct line

### DIFF
--- a/pkg/nuclide-flow-rpc/lib/prettyPrintTypes.js
+++ b/pkg/nuclide-flow-rpc/lib/prettyPrintTypes.js
@@ -66,7 +66,11 @@ type Group = {
 
 function parseGroups(str) {
   const rootGroup: Group = {
-    elements: [{ start: 0, end: -1, groups: [] }],
+    elements: [{
+      start: 0,
+      end: -1,
+      groups: []
+    }],
     isExact: false,
     exactChar: '',
     openChar: '',
@@ -79,7 +83,7 @@ function parseGroups(str) {
   let currentGroup: Group = rootGroup;
   let i = 0;
 
-  function pushGroup() {
+  function pushGroup(isExact) {
     const group = {
       start: i,
       end: -1,
@@ -91,16 +95,19 @@ function parseGroups(str) {
       parentGroup: currentGroup,
     };
     if (isExact) i++;
-    group.elements.push({ start: i + 1, end: -1, groups: [] });
+    group.elements.push({
+      start: i + 1,
+      end: -1,
+      groups: []
+    });
     const currentElement = last(currentGroup.elements);
     currentElement.groups.push(group);
     currentGroup = group;
   }
 
   function popGroup() {
-    const isExact = currentGroup.isExact
     const currentElement = last(currentGroup.elements);
-    currentElement.end = isExact ? i - 1 : i;
+    currentElement.end = currentGroup.isExact ? i - 1 : i;
     currentGroup.end = i + 1;
     const parentGroup = currentGroup.parentGroup;
     if (!parentGroup) {
@@ -117,7 +124,7 @@ function parseGroups(str) {
 
   for (; i < str.length; ++i) {
     if (openGroup.indexOf(str[i]) !== -1) {
-      pushGroup(str[i] === '{' && str[i+1] === '|');
+      pushGroup(str[i] === '{' && str[i + 1] === '|');
     }
 
     if (

--- a/pkg/nuclide-flow-rpc/lib/prettyPrintTypes.js
+++ b/pkg/nuclide-flow-rpc/lib/prettyPrintTypes.js
@@ -57,6 +57,8 @@ type Group = {
   elements: Array<Element>,
   openChar: string,
   closeChar: string,
+  exactChar: '|' | '',
+  isExact: boolean,
   start: number,
   end: number,
   parentGroup: ?Group,
@@ -64,7 +66,9 @@ type Group = {
 
 function parseGroups(str) {
   const rootGroup: Group = {
-    elements: [{start: 0, end: -1, groups: []}],
+    elements: [{ start: 0, end: -1, groups: [] }],
+    isExact: false,
+    exactChar: '',
     openChar: '',
     closeChar: '',
     start: 0,
@@ -81,17 +85,22 @@ function parseGroups(str) {
       end: -1,
       openChar: str[i],
       closeChar: closeGroup[openGroup.indexOf(str[i])],
-      elements: [{start: i + 1, end: -1, groups: []}],
+      exactChar: isExact ? '|' : '',
+      isExact: isExact,
+      elements: [],
       parentGroup: currentGroup,
     };
+    if (isExact) i++;
+    group.elements.push({ start: i + 1, end: -1, groups: [] });
     const currentElement = last(currentGroup.elements);
     currentElement.groups.push(group);
     currentGroup = group;
   }
 
   function popGroup() {
+    const isExact = currentGroup.isExact
     const currentElement = last(currentGroup.elements);
-    currentElement.end = i;
+    currentElement.end = isExact ? i - 1 : i;
     currentGroup.end = i + 1;
     const parentGroup = currentGroup.parentGroup;
     if (!parentGroup) {
@@ -108,7 +117,7 @@ function parseGroups(str) {
 
   for (; i < str.length; ++i) {
     if (openGroup.indexOf(str[i]) !== -1) {
-      pushGroup();
+      pushGroup(str[i] === '{' && str[i+1] === '|');
     }
 
     if (
@@ -137,28 +146,28 @@ function printGroups(str, rootGroup, max) {
   }
 
   function printMultiLineGroup(group, indent) {
-    let output = group.openChar + '\n';
+    let output = group.openChar + group.exactChar + '\n';
     group.elements.forEach(element => {
       output += printElement(element, indent + 1, /* singleLine */ false);
     });
-    output += getIndent(indent) + group.closeChar;
+    output += getIndent(indent) + group.exactChar + group.closeChar;
     return output;
   }
 
   function printSingleLineGroupWithoutEnforcingChildren(group, indent) {
-    let output = group.openChar;
+    let output = group.openChar + group.exactChar;
     group.elements.forEach(childGroup => {
       output += printElement(childGroup, indent, /* singleLine */ false).trim();
     });
-    return output + group.closeChar;
+    return output + group.exactChar + group.closeChar;
   }
 
   function printSingleLineGroup(group, indent) {
-    let output = group.openChar;
+    let output = group.openChar + group.exactChar;
     group.elements.forEach(childGroup => {
       output += printElement(childGroup, indent, /* singleLine */ true);
     });
-    return output + group.closeChar;
+    return output + group.exactChar + group.closeChar;
   }
 
   function printGroup(group, indent, singleLine) {

--- a/pkg/nuclide-flow-rpc/lib/prettyPrintTypes.js
+++ b/pkg/nuclide-flow-rpc/lib/prettyPrintTypes.js
@@ -66,11 +66,13 @@ type Group = {
 
 function parseGroups(str) {
   const rootGroup: Group = {
-    elements: [{
-      start: 0,
-      end: -1,
-      groups: []
-    }],
+    elements: [
+      {
+        start: 0,
+        end: -1,
+        groups: [],
+      },
+    ],
     isExact: false,
     exactChar: '',
     openChar: '',
@@ -90,15 +92,17 @@ function parseGroups(str) {
       openChar: str[i],
       closeChar: closeGroup[openGroup.indexOf(str[i])],
       exactChar: isExact ? '|' : '',
-      isExact: isExact,
+      isExact,
       elements: [],
       parentGroup: currentGroup,
     };
-    if (isExact) i++;
+    if (isExact) {
+      i++;
+    }
     group.elements.push({
       start: i + 1,
       end: -1,
-      groups: []
+      groups: [],
     });
     const currentElement = last(currentGroup.elements);
     currentElement.groups.push(group);


### PR DESCRIPTION
Currently the flow type printer will output exact object types like this

```js
{
  |foo: number,
  bar: 'bar' | 'baz'|
}
```

This change makes it so it outputs the following:

```js
{|
  foo: number,
  bar: 'bar' | 'baz'
|}
```