### PR TITLE
[nuclide][windows] Fix which

### DIFF
--- a/modules/nuclide-commons/spec/which-spec.js
+++ b/modules/nuclide-commons/spec/which-spec.js
@@ -46,7 +46,7 @@ describe('which', () => {
     it('calls where on Windows', () => {
       const param: string = '';
       which(param);
-      expect(runCommand).toHaveBeenCalledWith('where', [`.\\${param}`]);
+      expect(runCommand).toHaveBeenCalledWith('where', ['']);
     });
 
     it('returns the first match', () => {

--- a/modules/nuclide-commons/spec/which-spec.js
+++ b/modules/nuclide-commons/spec/which-spec.js
@@ -46,7 +46,7 @@ describe('which', () => {
     it('calls where on Windows', () => {
       const param: string = '';
       which(param);
-      expect(runCommand).toHaveBeenCalledWith('where', [`.:${param}`]);
+      expect(runCommand).toHaveBeenCalledWith('where', [`.\\${param}`]);
     });
 
     it('returns the first match', () => {

--- a/modules/nuclide-commons/which.js
+++ b/modules/nuclide-commons/which.js
@@ -24,13 +24,9 @@ import {runCommand} from './process';
 
 function sanitizePathForWindows(path: string): string {
   if (nuclideUri.basename(path) === path) {
-    // simple binary in $PATH
-    return path;
-  } else if (path.includes(':')) {
-    // already formatted for where
+    // simple binary in $PATH like `flow`
     return path;
   } else {
-    // a well formed path
     return `${nuclideUri.dirname(path)}:${nuclideUri.basename(path)}`;
   }
 }

--- a/modules/nuclide-commons/which.js
+++ b/modules/nuclide-commons/which.js
@@ -10,10 +10,10 @@
  * @format
  */
 
-import os from "os";
-import nuclideUri from "./nuclideUri";
+import os from 'os';
+import nuclideUri from './nuclideUri';
 
-import { runCommand } from "./process";
+import {runCommand} from './process';
 
 /**
  * Provides a cross-platform way to check whether a binary is available.
@@ -26,7 +26,7 @@ function sanitizePathForWindows(path: string): string {
   if (nuclideUri.basename(path) === path) {
     // simple binary in $PATH
     return path;
-  } else if (path.includes(":")) {
+  } else if (path.includes(':')) {
     // already formatted for where
     return path;
   } else {
@@ -36,8 +36,8 @@ function sanitizePathForWindows(path: string): string {
 }
 
 export default (async function which(path: string): Promise<?string> {
-  const isWindows = process.platform === "win32";
-  const whichCommand = isWindows ? "where" : "which";
+  const isWindows = process.platform === 'win32';
+  const whichCommand = isWindows ? 'where' : 'which';
   const searchPath = isWindows ? sanitizePathForWindows(path) : path;
   try {
     const result = await runCommand(whichCommand, [searchPath]).toPromise();

--- a/modules/nuclide-commons/which.js
+++ b/modules/nuclide-commons/which.js
@@ -21,12 +21,21 @@ import {runCommand} from './process';
  * We ran into problems with the npm `which` package (the nature of which I unfortunately don't
  * remember) so we can use this for now.
  */
+
+function sanitizePathForWindows(path: string): string {
+  if (nuclideUri.basename(path) === path) { // simple binary in $PATH
+    return path;
+  } else if(path.includes(':')) { // already formatted for where
+    return path;
+  } else { // a well formed path
+    return `${nuclideUri.dirname(path)}:${nuclideUri.basename(path)}`;
+  }
+}
+
 export default (async function which(path: string): Promise<?string> {
   const isWindows = process.platform === 'win32';
   const whichCommand = isWindows ? 'where' : 'which';
-  const searchPath = isWindows
-    ? `${nuclideUri.dirname(path)}:${nuclideUri.basename(path)}`
-    : path;
+  const searchPath = isWindows ? sanitizePathForWindows(path) : path;
   try {
     const result = await runCommand(whichCommand, [searchPath]).toPromise();
     return result.split(os.EOL)[0];

--- a/modules/nuclide-commons/which.js
+++ b/modules/nuclide-commons/which.js
@@ -10,10 +10,10 @@
  * @format
  */
 
-import os from 'os';
-import nuclideUri from './nuclideUri';
+import os from "os";
+import nuclideUri from "./nuclideUri";
 
-import {runCommand} from './process';
+import { runCommand } from "./process";
 
 /**
  * Provides a cross-platform way to check whether a binary is available.
@@ -23,18 +23,21 @@ import {runCommand} from './process';
  */
 
 function sanitizePathForWindows(path: string): string {
-  if (nuclideUri.basename(path) === path) { // simple binary in $PATH
+  if (nuclideUri.basename(path) === path) {
+    // simple binary in $PATH
     return path;
-  } else if(path.includes(':')) { // already formatted for where
+  } else if (path.includes(":")) {
+    // already formatted for where
     return path;
-  } else { // a well formed path
+  } else {
+    // a well formed path
     return `${nuclideUri.dirname(path)}:${nuclideUri.basename(path)}`;
   }
 }
 
 export default (async function which(path: string): Promise<?string> {
-  const isWindows = process.platform === 'win32';
-  const whichCommand = isWindows ? 'where' : 'which';
+  const isWindows = process.platform === "win32";
+  const whichCommand = isWindows ? "where" : "which";
   const searchPath = isWindows ? sanitizePathForWindows(path) : path;
   try {
     const result = await runCommand(whichCommand, [searchPath]).toPromise();

--- a/pkg/nuclide-flow-rpc/lib/FlowExecInfoContainer.js
+++ b/pkg/nuclide-flow-rpc/lib/FlowExecInfoContainer.js
@@ -202,10 +202,7 @@ async function canFindFlow(flowPath: string): Promise<boolean> {
     // "flow.exe", format the path correctly to pass to `where <flow>`
     const dirPath = nuclideUri.dirname(flowPath);
     if (dirPath != null && dirPath !== '' && dirPath !== '.') {
-      const whichPath = `${nuclideUri.dirname(flowPath)}:${nuclideUri.basename(
-        flowPath,
-      )}`;
-      return (await which(whichPath)) != null;
+      return (await which(flowPath)) != null;
     }
   }
 


### PR DESCRIPTION
which on windows was assuming that the path was always a well formed path, however it's receiving inputs like `C:\nuclide\node_modules\.bin:flow`, which breaks this tool.

Also, `where` supports finding binaries in the $PATH, e.g. `where flow`

I've fixed this function to support these functionalities

test: flow works on nuclide by using the `run flow from local project` setting