### PR TITLE
[nuclide][device panel] improvements in the adb/sdb config dialog

### DIFF
--- a/pkg/nuclide-adb-sdb/lib/device-panel/ATConfigurePathTaskProvider.js
+++ b/pkg/nuclide-adb-sdb/lib/device-panel/ATConfigurePathTaskProvider.js
@@ -44,7 +44,6 @@ export class ATConfigurePathTaskProvider implements DeviceTypeTaskProvider {
             <ATCustomDBPathModal
               dismiss={dismiss}
               activePath={fullConfig.active}
-              activePort={fullConfig.ports[fullConfig.ports.length - 1]}
               currentCustomPath={this._bridge.getCustomDebugBridgePath(host)}
               registeredPaths={fullConfig.all}
               setCustomPath={customPath =>

--- a/pkg/nuclide-adb-sdb/lib/device-panel/ui/ATCustomDBPathModal.js
+++ b/pkg/nuclide-adb-sdb/lib/device-panel/ui/ATCustomDBPathModal.js
@@ -20,7 +20,6 @@ type Props = {|
   setCustomPath: (path: ?string) => void,
   dismiss: () => mixed,
   activePath: ?string,
-  activePort: ?number,
   currentCustomPath: ?string,
   registeredPaths: string[],
 |};
@@ -48,9 +47,15 @@ export class ATCustomDBPathModal extends React.Component<Props, State> {
     this.setState({customPath: customPath.length === 0 ? null : customPath});
   };
 
+  _handleCopyToClipboard = (): void => {
+    if (this.props.activePath != null) {
+      atom.clipboard.write(this.props.activePath);
+    }
+  };
+
   _getActiveConfig(): React.Element<any> {
     return (
-      <div>
+      <div className="nuclide-adb-sdb-path">
         <label>
           Active {this.props.type} path:{' '}
           <i>
@@ -59,15 +64,14 @@ export class ATCustomDBPathModal extends React.Component<Props, State> {
             </strong>
           </i>
         </label>
-        <label>
-          Active {this.props.type} port:{' '}
-          <i>
-            <strong>
-              {// flowlint-next-line sketchy-null-number:off
-              this.props.activePort || 'default'}
-            </strong>
-          </i>
-        </label>
+        {this.props.activePath == null
+          ? null
+          : <Button
+              onClick={this._handleCopyToClipboard}
+              size="SMALL"
+              className="nuclide-adb-sdb-copy-path-btn">
+              Copy path to clipboard
+            </Button>}
       </div>
     );
   }

--- a/pkg/nuclide-adb-sdb/styles/nuclide-adb-sdb.less
+++ b/pkg/nuclide-adb-sdb/styles/nuclide-adb-sdb.less
@@ -10,3 +10,12 @@ atom-panel.modal.nuclide-adb-sdb-custom-path-modal {
   display: flex;
   justify-content: flex-end;
 }
+
+.nuclide-adb-sdb-path {
+  display: flex;
+  flex-direction: column;
+}
+
+.nuclide-adb-sdb-copy-path-btn {
+  width: min-content;
+}


### PR DESCRIPTION
don't show the ports, because they should be displayed along with each independent device

add a button for easily copying the adb or sdb paths. Sometimes they are long and this is quite handy when debugging
![image](https://user-images.githubusercontent.com/1613874/30237924-44c182a8-94f1-11e7-9c9c-0ea5ea4c3f36.png)
