### PR TITLE
Add a "revealTooltip" option to the busy signal API

### DIFF
--- a/modules/atom-ide-ui/pkg/atom-ide-busy-signal/lib/BusyMessageInstance.js
+++ b/modules/atom-ide-ui/pkg/atom-ide-busy-signal/lib/BusyMessageInstance.js
@@ -27,6 +27,7 @@ export class BusyMessageInstance {
   _currentTitle: ?string = null;
   _isVisibleForDebounce: boolean = true;
   _isVisibleForFile: boolean = true;
+  _revealTooltip: boolean = false;
 
   constructor(
     publishCallback: () => void,
@@ -91,6 +92,14 @@ export class BusyMessageInstance {
       this._isVisibleForDebounce &&
       this._currentTitle != null
     );
+  }
+
+  setRevealTooltip(val: boolean): void {
+    this._revealTooltip = val;
+  }
+
+  shouldRevealTooltip(): boolean {
+    return this._revealTooltip;
   }
 
   compare(that: BusyMessageInstance): number {

--- a/modules/atom-ide-ui/pkg/atom-ide-busy-signal/lib/MessageStore.js
+++ b/modules/atom-ide-ui/pkg/atom-ide-busy-signal/lib/MessageStore.js
@@ -46,6 +46,10 @@ export class MessageStore {
   }
 
   _publish(): void {
+    // Currently visible messages should no longer reveal the tooltip again.
+    this._currentVisibleMessages.forEach(message =>
+      message.setRevealTooltip(false),
+    );
     const visibleMessages = [...this._messages]
       .filter(m => m.isVisible())
       .sort((m1, m2) => m1.compare(m2));
@@ -118,6 +122,12 @@ export class MessageStore {
         message.setIsVisibleForFile(newVisible);
       });
       messageDisposables.add(teardown);
+    }
+
+    if (options.revealTooltip) {
+      // When the UI component receives this message, it'll reveal the tooltip.
+      // We'll clear this flag after the message becomes visible the first time.
+      message.setRevealTooltip(true);
     }
 
     message.setTitle(title);

--- a/modules/atom-ide-ui/pkg/atom-ide-busy-signal/lib/StatusBarTile.js
+++ b/modules/atom-ide-ui/pkg/atom-ide-busy-signal/lib/StatusBarTile.js
@@ -124,6 +124,8 @@ export default class StatusBarTile {
       } else {
         this._isMouseOverItem = false;
       }
+    } else if (messages.some(message => message.shouldRevealTooltip())) {
+      this._ensureTooltip();
     }
   }
 

--- a/modules/atom-ide-ui/pkg/atom-ide-busy-signal/lib/types.js
+++ b/modules/atom-ide-ui/pkg/atom-ide-busy-signal/lib/types.js
@@ -24,6 +24,9 @@ export type BusySignalOptions = {|
   debounce?: boolean,
   // If onClick is set, then the tooltip will be clickable. Default = null.
   onDidClick?: () => void,
+  // If set to true, the busy signal tooltip will be immediately revealed
+  // when it first becomes visible (without explicit mouse interaction).
+  revealTooltip?: boolean,
 |};
 
 export type BusySignalService = {


### PR DESCRIPTION
Synced from facebook-atom/atom-ide-ui#55