### PR TITLE
Minor datatip fixes

### DIFF
--- a/modules/atom-ide-ui/pkg/atom-ide-datatip/lib/DatatipManager.js
+++ b/modules/atom-ide-ui/pkg/atom-ide-datatip/lib/DatatipManager.js
@@ -326,6 +326,11 @@ class DatatipManagerForEditor {
       Observable.fromEvent(this._editorView, 'keydown').subscribe(e => {
         const modifierKey = getModifierKeyFromKeyboardEvent(e);
         if (modifierKey) {
+          // On Windows, key repeat applies to modifier keys too!
+          // So it's quite possible that we hit this twice without hitting keyup.
+          if (this._heldKeys.has(modifierKey)) {
+            return;
+          }
           this._heldKeys.add(modifierKey);
           if (this._datatipState !== DatatipState.HIDDEN) {
             this._fetchInResponseToKeyPress();
@@ -602,11 +607,13 @@ class DatatipManagerForEditor {
       this._datatipState === DatatipState.HIDDEN ||
       this._datatipState === DatatipState.FETCHING
     ) {
-      this._blacklistedPosition = getBufferPosition(
-        this._editor,
-        this._editorView,
-        this._lastMoveEvent,
-      );
+      if (this._blacklistedPosition == null) {
+        this._blacklistedPosition = getBufferPosition(
+          this._editor,
+          this._editorView,
+          this._lastMoveEvent,
+        );
+      }
       return;
     }
 


### PR DESCRIPTION
1) On Windows, modifier keys are also subject to key repeat. So we shouldn't try to repeatedly fetch modifier datatips (https://github.com/facebook-atom/atom-ide-ui/issues/20)

2) We try to blacklist the current mouse position in certain scenarios. However, since moving the mouse clears the blacklist, it's only safe to set this once. `getBufferPosition` forces a layout recalculation so it's expensive! (https://github.com/facebook-atom/atom-ide-ui/issues/94)