### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,10 @@ possible. The
 certain limitations around distribution. However, this does not affect your
 ability to fork the project and make contributions.
 
+## Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct) so that you can understand what actions will and will not be tolerated.
+
 ## Our Development Process
 Nuclide is currently developed in Facebook's internal repositories and then
 exported out to GitHub by a Facebook team member. We invite you to submit pull


### PR DESCRIPTION
**what is the change?:**
Adding a document linking to the Facebook Open Source Code of Conduct,
for visibility and to meet Github community standards.

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will complete [React's Community Profile](https://github.com/facebook/react/community)
checklist and increase the visibility of our COC.

We also added a link to the COC in the `CONTRIBUTING.md` file in case folks miss the separate file.

**test plan:**
Viewing it on my branch -
![screen shot 2017-11-20 at 5 47 13 pm](https://user-images.githubusercontent.com/1114467/33050740-4d67b158-ce1b-11e7-8424-984116262d93.png)
![screen shot 2017-11-20 at 5 49 33 pm](https://user-images.githubusercontent.com/1114467/33050741-4d7c9014-ce1b-11e7-8844-9bd2088d248d.png)


**issue:**
internal task t23481323