### PR TITLE
Set the correct MagicPython package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "language-swift",
     "language-thrift",
     "language-scala",
-    "MagicPython",
+    "magicpython",
     "nuclide-format-js:0.0.43",
     "set-syntax",
     "sort-lines"


### PR DESCRIPTION
After installing Nuclide I've set it to automatically fetch and install all recommended packages. However, I've had this alert popping up every single time I opened Nuclide:

![image](https://user-images.githubusercontent.com/1261453/34462725-04df5386-ee29-11e7-9e16-7c722d220ccb.png)

It actually looked like the MagicPython package was getting installed, but it actually wasn't (btw I'm running Atom 1.23.1, Nuclide 0.273.0 on MacOS High Sierra).

Tried installing it manually running `apm install MagicPython` but it errored out:

```
Installing MagicPython to /Users/fknussel/.atom/packages ✓
fs.js:640
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: ENOENT: no such file or directory, open '/Users/fknussel/.atom/packages/MagicPython/package.json'
    at Error (native)
    at Object.fs.openSync (fs.js:640:18)
    at Proxy.fs.readFileSync (fs.js:508:33)
    at Proxy.fs.readFileSync (/private/var/folders/4j/6cfp1zxj6_x9ywq8g_nj3b8m0000gn/T/AppTranslocation/4FCD6043-6D3C-464A-B0B9-FF1FCD713E7C/d/Atom.app/Contents/Resources/app/apm/node_modules/asar-require/lib/require.js:86:27)
    at /private/var/folders/4j/6cfp1zxj6_x9ywq8g_nj3b8m0000gn/T/AppTranslocation/4FCD6043-6D3C-464A-B0B9-FF1FCD713E7C/d/Atom.app/Contents/Resources/app/apm/lib/install.js:476:42
    at fn (/private/var/folders/4j/6cfp1zxj6_x9ywq8g_nj3b8m0000gn/T/AppTranslocation/4FCD6043-6D3C-464A-B0B9-FF1FCD713E7C/d/Atom.app/Contents/Resources/app/apm/node_modules/async/lib/async.js:582:34)
    at Immediate.<anonymous> (/private/var/folders/4j/6cfp1zxj6_x9ywq8g_nj3b8m0000gn/T/AppTranslocation/4FCD6043-6D3C-464A-B0B9-FF1FCD713E7C/d/Atom.app/Contents/Resources/app/apm/node_modules/async/lib/async.js:498:34)
    at runCallback (timers.js:649:20)
    at tryOnImmediate (timers.js:622:5)
    at processImmediate [as _immediateCallback] (timers.js:594:5)
```

Not sure whether the [package name](https://atom.io/packages/MagicPython) changed recently, but switching to the lower-case name version seemed to do the trick:

```
apm install magicpython
```

Never got the "installing MagicPython" alert message again on boot up.

Not sure this is just me, but anyway I reckon this should be changed to reflect the actual name of the package.