### PR TITLE
Allow disabling of hiding VCS ignored files

### DIFF
--- a/pkg/nuclide-file-tree/lib/FileTreeActions.js
+++ b/pkg/nuclide-file-tree/lib/FileTreeActions.js
@@ -145,6 +145,13 @@ export default class FileTreeActions {
     });
   }
 
+  setHideVcsIgnoredPaths(hideVcsIgnoredPaths: boolean): void {
+    this._dispatcher.dispatch({
+      actionType: ActionTypes.SET_HIDE_VCS_IGNORED_PATHS,
+      hideVcsIgnoredPaths,
+    });
+  }
+
   setHideIgnoredNames(hideIgnoredNames: boolean): void {
     this._dispatcher.dispatch({
       actionType: ActionTypes.SET_HIDE_IGNORED_NAMES,

--- a/pkg/nuclide-file-tree/lib/FileTreeController.js
+++ b/pkg/nuclide-file-tree/lib/FileTreeController.js
@@ -393,6 +393,10 @@ export default class FileTreeController {
     this._actions.setExcludeVcsIgnoredPaths(excludeVcsIgnoredPaths);
   }
 
+  setHideVcsIgnoredPaths(hideVcsIgnoredPaths: boolean): void {
+    this._actions.setHideVcsIgnoredPaths(hideVcsIgnoredPaths);
+  }
+
   setHideIgnoredNames(hideIgnoredNames: boolean): void {
     this._actions.setHideIgnoredNames(hideIgnoredNames);
   }

--- a/pkg/nuclide-file-tree/lib/FileTreeDispatcher.js
+++ b/pkg/nuclide-file-tree/lib/FileTreeDispatcher.js
@@ -42,6 +42,10 @@ export type FileTreeAction =
       excludeVcsIgnoredPaths: boolean,
     }
   | {
+      actionType: 'SET_HIDE_VCS_IGNORED_PATHS',
+      hideVcsIgnoredPaths: boolean,
+    }
+  | {
       actionType: 'EXPAND_NODE_DEEP',
       rootKey: NuclideUri,
       nodeKey: NuclideUri,
@@ -253,6 +257,7 @@ export const ActionTypes = Object.freeze({
   EXPAND_NODE_DEEP: 'EXPAND_NODE_DEEP',
   SET_CWD: 'SET_CWD',
   SET_HIDE_IGNORED_NAMES: 'SET_HIDE_IGNORED_NAMES',
+  SET_HIDE_VCS_IGNORED_PATHS: 'SET_HIDE_VCS_IGNORED_PATHS',
   SET_IS_CALCULATING_CHANGES: 'SET_IS_CALCULATING_CHANGES',
   SET_IGNORED_NAMES: 'SET_IGNORED_NAMES',
   SET_ROOT_KEYS: 'SET_ROOT_KEYS',

--- a/pkg/nuclide-file-tree/lib/FileTreeStore.js
+++ b/pkg/nuclide-file-tree/lib/FileTreeStore.js
@@ -71,6 +71,7 @@ export type StoreConfigData = {
   workingSet: WorkingSet,
   hideIgnoredNames: boolean,
   excludeVcsIgnoredPaths: boolean,
+  hideVcsIgnoredPaths: boolean,
   ignoredPatterns: Immutable.Set<Minimatch>,
   usePreviewTabs: boolean,
   focusEditorOnFileSelection: boolean,
@@ -93,6 +94,7 @@ export const DEFAULT_CONF = {
   editedWorkingSet: new WorkingSet(),
   hideIgnoredNames: true,
   excludeVcsIgnoredPaths: true,
+  hideVcsIgnoredPaths: true,
   ignoredPatterns: Immutable.Set(),
   usePreviewTabs: false,
   focusEditorOnFileSelection: true,
@@ -290,6 +292,12 @@ export class FileTreeStore {
     });
   }
 
+  _setHideVcsIgnoredPaths(hideVcsIgnoredPaths: boolean): void {
+    this._updateConf(conf => {
+      conf.hideVcsIgnoredPaths = hideVcsIgnoredPaths;
+    });
+  }
+
   _setHideIgnoredNames(hideIgnoredNames: boolean): void {
     this._updateConf(conf => {
       conf.hideIgnoredNames = hideIgnoredNames;
@@ -376,6 +384,9 @@ export class FileTreeStore {
         break;
       case ActionTypes.SET_EXCLUDE_VCS_IGNORED_PATHS:
         this._setExcludeVcsIgnoredPaths(payload.excludeVcsIgnoredPaths);
+        break;
+      case ActionTypes.SET_HIDE_VCS_IGNORED_PATHS:
+        this._setHideVcsIgnoredPaths(payload.hideVcsIgnoredPaths);
         break;
       case ActionTypes.SET_USE_PREVIEW_TABS:
         this._setUsePreviewTabs(payload.usePreviewTabs);
@@ -1272,6 +1283,7 @@ export class FileTreeStore {
     return {
       hideIgnoredNames: this._conf.hideIgnoredNames,
       excludeVcsIgnoredPaths: this._conf.excludeVcsIgnoredPaths,
+      hideVcsIgnoredPaths: this._conf.hideVcsIgnoredPaths,
       usePreviewTabs: this._conf.usePreviewTabs,
       focusEditorOnFileSelection: this._conf.focusEditorOnFileSelection,
       isEditingWorkingSet: this._conf.isEditingWorkingSet,

--- a/pkg/nuclide-file-tree/lib/MemoizedFieldsDeriver.js
+++ b/pkg/nuclide-file-tree/lib/MemoizedFieldsDeriver.js
@@ -201,6 +201,7 @@ export class MemoizedFieldsDeriver {
     if (
       store.isIgnored !== isIgnored ||
       store.excludeVcsIgnoredPaths !== conf.excludeVcsIgnoredPaths ||
+      store.hideVcsIgnoredPaths !== conf.hideVcsIgnoredPaths ||
       store.hideIgnoredNames !== conf.hideIgnoredNames ||
       store.ignoredPatterns !== conf.ignoredPatterns ||
       store.isEditingWorkingSet !== conf.isEditingWorkingSet ||
@@ -209,13 +210,18 @@ export class MemoizedFieldsDeriver {
     ) {
       store.isIgnored = isIgnored;
       store.excludeVcsIgnoredPaths = conf.excludeVcsIgnoredPaths;
+      store.hideVcsIgnoredPaths = conf.hideVcsIgnoredPaths;
       store.hideIgnoredNames = conf.hideIgnoredNames;
       store.ignoredPatterns = conf.ignoredPatterns;
       store.isEditingWorkingSet = conf.isEditingWorkingSet;
       store.containedInWorkingSet = containedInWorkingSet;
       store.containedInOpenFilesWorkingSet = containedInOpenFilesWorkingSet;
 
-      if (store.isIgnored && store.excludeVcsIgnoredPaths) {
+      if (
+        store.isIgnored &&
+        store.excludeVcsIgnoredPaths &&
+        store.hideVcsIgnoredPaths
+      ) {
         store.shouldBeShown = false;
       } else if (
         store.hideIgnoredNames &&

--- a/pkg/nuclide-file-tree/lib/main.js
+++ b/pkg/nuclide-file-tree/lib/main.js
@@ -106,6 +106,7 @@ class Activation {
     this._restored = state.restored === true;
 
     const excludeVcsIgnoredPathsSetting = 'core.excludeVcsIgnoredPaths';
+    const hideVcsIgnoredPathsSetting = 'nuclide-file-tree.hideVcsIgnoredPaths';
     const hideIgnoredNamesSetting = 'nuclide-file-tree.hideIgnoredNames';
     const ignoredNamesSetting = 'core.ignoredNames';
     const prefixKeyNavSetting =
@@ -138,6 +139,9 @@ class Activation {
       ),
       featureConfig.observe(hideIgnoredNamesSetting, (x: any) =>
         this._setHideIgnoredNames(x),
+      ),
+      featureConfig.observe(hideVcsIgnoredPathsSetting, (x: any) =>
+        this._setHideVcsIgnoredPaths(x),
       ),
       atom.config.observe(
         excludeVcsIgnoredPathsSetting,
@@ -293,6 +297,10 @@ class Activation {
 
   _setExcludeVcsIgnoredPaths(excludeVcsIgnoredPaths: boolean): void {
     this._fileTreeController.setExcludeVcsIgnoredPaths(excludeVcsIgnoredPaths);
+  }
+
+  _setHideVcsIgnoredPaths(hideVcsIgnoredPaths: boolean): void {
+    this._fileTreeController.setHideVcsIgnoredPaths(hideVcsIgnoredPaths);
   }
 
   _setHideIgnoredNames(hideIgnoredNames: boolean): void {

--- a/pkg/nuclide-file-tree/package.json
+++ b/pkg/nuclide-file-tree/package.json
@@ -63,6 +63,13 @@
         "default": true,
         "description": "Hide paths that match the \"Ignored Names\" under \"Settings > Core Settings\""
       },
+      "hideVcsIgnoredPaths": {
+        "title": "Hide VCS Ignored Paths",
+        "type": "boolean",
+        "default": true,
+        "description":
+          "Files and directories ignored by the current project's version control system will be hidden."
+      },
       "allowKeyboardPrefixNavigation": {
         "title": "Enable prefix-based keyboard navigation",
         "type": "boolean",

--- a/pkg/nuclide-file-tree/spec/FileTreeNode-spec.js
+++ b/pkg/nuclide-file-tree/spec/FileTreeNode-spec.js
@@ -20,6 +20,7 @@ const CONF = {
   workingSet: new WorkingSet(),
   editedWorkingSet: new WorkingSet(),
   hideIgnoredNames: true,
+  hideVcsIgnoredPaths: true,
   excludeVcsIgnoredPaths: true,
   ignoredPatterns: Immutable.Set(),
   repositories: Immutable.Set(),

--- a/pkg/nuclide-file-tree/spec/FileTreeStore-spec.js
+++ b/pkg/nuclide-file-tree/spec/FileTreeStore-spec.js
@@ -417,6 +417,7 @@ describe('FileTreeStore', () => {
       actions.setRootKeys([dir1]);
       actions.expandNode(dir1, fooTxt);
       actions.setExcludeVcsIgnoredPaths(true);
+      actions.setHideVcsIgnoredPaths(true);
 
       const mockRepo = new MockRepository();
       store._updateConf(conf => {
@@ -433,6 +434,24 @@ describe('FileTreeStore', () => {
       actions.setRootKeys([dir1]);
       actions.expandNode(dir1, fooTxt);
       actions.setExcludeVcsIgnoredPaths(false);
+      actions.setHideVcsIgnoredPaths(false);
+
+      const mockRepo = new MockRepository();
+      store._updateConf(conf => {
+        conf.reposByRoot[dir1] = (mockRepo: any);
+      });
+
+      await loadChildKeys(dir1, dir1);
+      expect(shownChildren(dir1, dir1).length).toBe(1);
+    });
+  });
+
+  it('includes vcs-excluded paths when explicitly told to', () => {
+    waitsForPromise(async () => {
+      actions.setRootKeys([dir1]);
+      actions.expandNode(dir1, fooTxt);
+      actions.setExcludeVcsIgnoredPaths(true);
+      actions.setHideVcsIgnoredPaths(false);
 
       const mockRepo = new MockRepository();
       store._updateConf(conf => {


### PR DESCRIPTION
Fixes #491 .

Have a file tree, like today:
<img width="304" alt="screenshot 2018-03-03 17 34 48" src="https://user-images.githubusercontent.com/1473433/36937346-b4e536d6-1f09-11e8-8557-14c6e6c6e70c.png">
There's a new setting, "Hide VCS Ignored Paths", defaulted to `true`:
<img width="756" alt="screenshot 2018-03-03 17 34 56" src="https://user-images.githubusercontent.com/1473433/36937347-b4fb982c-1f09-11e8-8dc7-cda7543252b0.png">
Toggle it, and see git-ignored files and folders in the file tree:
<img width="296" alt="screenshot 2018-03-03 17 35 06" src="https://user-images.githubusercontent.com/1473433/36937348-b5136e02-1f09-11e8-9a26-92e13faf5f68.png">
