### PR TITLE
Fix exception on jsimports startup (#1448)

### DIFF
--- a/pkg/nuclide-js-imports-server/spec/UndefinedSymbolManager-spec.js
+++ b/pkg/nuclide-js-imports-server/spec/UndefinedSymbolManager-spec.js
@@ -275,4 +275,9 @@ describe('UndefinedSymbolManager', () => {
     const undefinedSymbols = manager.findUndefined(ast);
     expect(undefinedSymbols.length).toBe(0);
   });
+
+  it('should not error with non-standard environments', () => {
+    // eslint-disable-next-line no-new
+    new UndefinedSymbolManager(['asdf']);
+  });
 });

--- a/pkg/nuclide-js-imports-server/src/lib/UndefinedSymbolManager.js
+++ b/pkg/nuclide-js-imports-server/src/lib/UndefinedSymbolManager.js
@@ -29,9 +29,11 @@ export class UndefinedSymbolManager {
   constructor(envs: Array<string>) {
     this.globals = new Set(BUILT_INS);
     envs.forEach(env => {
-      Object.keys(globalsJSON[env]).forEach(globalVar => {
-        this.globals.add(globalVar);
-      });
+      if (globalsJSON[env]) {
+        Object.keys(globalsJSON[env]).forEach(globalVar => {
+          this.globals.add(globalVar);
+        });
+      }
     });
   }
 


### PR DESCRIPTION
@FDiskas I think this is the issue in #1448. Could you try manually patching this into `~/.atom/packages/nuclide/pkg/nuclide-js-imports-server/src/lib/UndefinedSymbolManager.js` to see if that does the trick?