### PR TITLE
Add Option to change font for nuclide-terminal

### DIFF
--- a/pkg/nuclide-terminal/lib/terminal-view.js
+++ b/pkg/nuclide-terminal/lib/terminal-view.js
@@ -54,6 +54,8 @@ const SCROLLBACK_CONFIG = 'nuclide-terminal.scrollback';
 const CURSOR_STYLE_CONFIG = 'nuclide-terminal.cursorStyle';
 const CURSOR_BLINK_CONFIG = 'nuclide-terminal.cursorBlink';
 const FONT_FAMILY_CONFIG = 'nuclide-terminal.fontFamily';
+const FONT_SIZE_CONFIG = 'nuclide-terminal.fontSize';
+const LINE_HEIGHT_CONFIG = 'nuclide-terminal.lineHeight';
 const DOCUMENTATION_MESSAGE_CONFIG = 'nuclide-terminal.documentationMessage';
 const ADD_ESCAPE_COMMAND = 'nuclide-terminal:add-escape-prefix';
 const TMUX_CONTROLCONTROL_PREFIX = '\x1BP1000p';
@@ -132,18 +134,6 @@ export class TerminalView implements PtyClient {
             ...(info.preservedCommands || []),
           ]);
         }),
-      atom.config.onDidChange(
-        'editor.fontSize',
-        this._syncAtomStyle.bind(this),
-      ),
-      atom.config.onDidChange(
-        'editor.fontFamily',
-        this._syncAtomStyle.bind(this),
-      ),
-      atom.config.onDidChange(
-        'editor.lineHeight',
-        this._syncAtomStyle.bind(this),
-      ),
       atom.config.onDidChange('core.themes', this._syncAtomTheme.bind(this)),
       atom.themes.onDidChangeActiveThemes(this._syncAtomTheme.bind(this)),
     );
@@ -159,6 +149,8 @@ export class TerminalView implements PtyClient {
       cursorStyle: featureConfig.get(CURSOR_STYLE_CONFIG),
       scrollback: featureConfig.get(SCROLLBACK_CONFIG),
       fontFamily: featureConfig.get(FONT_FAMILY_CONFIG),
+      fontSize: featureConfig.get(FONT_SIZE_CONFIG),
+      lineHeight: featureConfig.get(LINE_HEIGHT_CONFIG),
     }));
     (div: any).terminal = terminal;
     terminal.open(this._div);
@@ -205,9 +197,17 @@ export class TerminalView implements PtyClient {
         .skip(1)
         .subscribe(scrollback => terminal.setOption('scrollback', scrollback)),
       featureConfig
+        .observeAsStream(FONT_SIZE_CONFIG)
+        .skip(1)
+        .subscribe(fontSize => terminal.setOption('fontSize', fontSize)),
+      featureConfig
         .observeAsStream(FONT_FAMILY_CONFIG)
         .skip(1)
         .subscribe(fontFamily => terminal.setOption('fontFamily', fontFamily)),
+      featureConfig
+        .observeAsStream(LINE_HEIGHT_CONFIG)
+        .skip(1)
+        .subscribe(lineHeight => terminal.setOption('lineHeight', lineHeight)),
       Observable.merge(
         Observable.fromEvent(this._terminal, 'focus'),
         Observable.fromEvent(window, 'resize'),
@@ -402,7 +402,7 @@ export class TerminalView implements PtyClient {
   }
 
   _syncAtomStyleItem(name: string): void {
-    const item = atom.config.get(`editor.${name}`);
+    const item = atom.config.get(`nuclide-terminal.${name}`);
     if (item != null && item !== '') {
       this._terminal.setOption(name, item);
     }

--- a/pkg/nuclide-terminal/lib/terminal-view.js
+++ b/pkg/nuclide-terminal/lib/terminal-view.js
@@ -53,6 +53,7 @@ const PRESERVED_COMMANDS_CONFIG = 'nuclide-terminal.preservedCommands';
 const SCROLLBACK_CONFIG = 'nuclide-terminal.scrollback';
 const CURSOR_STYLE_CONFIG = 'nuclide-terminal.cursorStyle';
 const CURSOR_BLINK_CONFIG = 'nuclide-terminal.cursorBlink';
+const FONT_FAMILY_CONFIG = 'nuclide-terminal.fontFamily';
 const DOCUMENTATION_MESSAGE_CONFIG = 'nuclide-terminal.documentationMessage';
 const ADD_ESCAPE_COMMAND = 'nuclide-terminal:add-escape-prefix';
 const TMUX_CONTROLCONTROL_PREFIX = '\x1BP1000p';
@@ -157,6 +158,7 @@ export class TerminalView implements PtyClient {
       cursorBlink: featureConfig.get(CURSOR_BLINK_CONFIG),
       cursorStyle: featureConfig.get(CURSOR_STYLE_CONFIG),
       scrollback: featureConfig.get(SCROLLBACK_CONFIG),
+      fontFamily: featureConfig.get(FONT_FAMILY_CONFIG),
     }));
     (div: any).terminal = terminal;
     terminal.open(this._div);
@@ -202,6 +204,10 @@ export class TerminalView implements PtyClient {
         .observeAsStream(SCROLLBACK_CONFIG)
         .skip(1)
         .subscribe(scrollback => terminal.setOption('scrollback', scrollback)),
+      featureConfig
+        .observeAsStream(FONT_FAMILY_CONFIG)
+        .skip(1)
+        .subscribe(fontFamily => terminal.setOption('fontFamily', fontFamily)),
       Observable.merge(
         Observable.fromEvent(this._terminal, 'focus'),
         Observable.fromEvent(window, 'resize'),

--- a/pkg/nuclide-terminal/package.json
+++ b/pkg/nuclide-terminal/package.json
@@ -40,6 +40,11 @@
         "type": "boolean",
         "default": false
       },
+      "fontFamily": {
+        "title": "Font Family",
+        "type": "string",
+        "default": "courier-new, courier, monospace"
+      },
       "documentationMessage": {
         "title": "Documentation Message",
         "type": "boolean",

--- a/pkg/nuclide-terminal/package.json
+++ b/pkg/nuclide-terminal/package.json
@@ -52,8 +52,8 @@
       },
       "lineHeight": {
         "title": "Line Height",
-        "type": "integer",
-        "default": 1
+        "type": "number",
+        "default": 1.5
       },
       "documentationMessage": {
         "title": "Documentation Message",

--- a/pkg/nuclide-terminal/package.json
+++ b/pkg/nuclide-terminal/package.json
@@ -45,6 +45,16 @@
         "type": "string",
         "default": "courier-new, courier, monospace"
       },
+      "fontSize": {
+        "title": "Font Size",
+        "type": "integer",
+        "default": 15
+      },
+      "lineHeight": {
+        "title": "Line Height",
+        "type": "integer",
+        "default": 1
+      },
       "documentationMessage": {
         "title": "Documentation Message",
         "type": "boolean",


### PR DESCRIPTION
I like to use the internal Terminal once in a while. But as xterm.js renders the terminal in a canvas I have to set the font in xterm.js and can't just change the css.
Sadly nuclide didn't have an option to change the font.
Now it does.