### PR TITLE
Allow structural subtyping of Hack shapes to get parsed correctly

### DIFF
--- a/pkg/nuclide-language-hack/grammars/hack.cson
+++ b/pkg/nuclide-language-hack/grammars/hack.cson
@@ -361,7 +361,7 @@
         'patterns': [
           {
             'begin': '(shape\\()'
-            'end': '(=>)'
+            'end': '(=>|\\.\\.\\.)'
             'endCaptures':
               '1': 'keyword.operator.key.php'
             'patterns':[

--- a/pkg/nuclide-language-hack/spec/fixtures/syntax_test_hack_typing.php
+++ b/pkg/nuclide-language-hack/spec/fixtures/syntax_test_hack_typing.php
@@ -135,6 +135,10 @@ function f(): shape('vc' => shape('vc' => int)) {
   //                                      ^^^ .storage.type.php
 }
 
+function f(): shape(...) {
+  //          ^^^^^^^^^^ storage.type.shape.php
+}
+
 class Something {
   public static function f(int $x, shape('vc' => int) $y): shape('vc' => int) {
     //                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.arguments.php


### PR DESCRIPTION
Specifically this allows shapes intended as a generic result (eg parsing
a JSON API response) to be typed, and the code to be formatted
correctly.

This is now formatted correctly:

```
function genFoo(): Awaitable<shape(...)> {
  // code
}
```