### PR TITLE
fix homebrew openssl path

### DIFF
--- a/modules/big-dig/src/server/certificates.js
+++ b/modules/big-dig/src/server/certificates.js
@@ -189,7 +189,7 @@ function generateEnvironmentForOpenSSLCalls(serverCommonName: string): Object {
   if (process.platform === 'darwin') {
     // High Sierra comes with LibreSSL by default, which is not supported.
     // Often, OpenSSL may be installed by Homebrew.
-    env.PATH = '/opt/homebrew/bin:' + env.PATH;
+    env.PATH = '/usr/local/opt/openssl/bin:' + env.PATH;
   }
   // Usually, we don't have to make the common name a SAN,
   // but our openssl.cnf requires a value via $OPENSSL_SAN.

--- a/pkg/nuclide-server/scripts/nuclide_certificates_generator.py
+++ b/pkg/nuclide-server/scripts/nuclide_certificates_generator.py
@@ -58,9 +58,9 @@ class NuclideCertificatesGenerator(object):
         self._env = os.environ.copy()
         if sys.platform == 'darwin':
             # High Sierra comes with LibreSSL by default.
-            # /opt/homebrew/bin sometimes has OpenSSL instead.
+            # /usr/local/opt/openssl/bin sometimes has OpenSSL instead.
             self._env['PATH'] = os.pathsep.join([
-                '/opt/homebrew/bin',
+                '/usr/local/opt/openssl/bin',
                 self._env.get('PATH', ''),
             ])
         # Set Subject Alternative Name.


### PR DESCRIPTION
Not sure what version of homebrew placed openssl in /opt/homebrew/bin, but the current installer places it in /usr/local/opt/openssl/bin.

I'm assuming openssl has not been linked in homebrew (made the default), or the path addition would be unnecessary.

I was unable to run nuclide-start-server on High Sierra (10.13.4) until I made this change. This seems to be because LibreSSL does not support environment variables in the included openssl.cnf.

