### PR TITLE
Use Node v9 for ESLint on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   environment:
     PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
+    # The prettier ESLint plugin is problematic in Node v7.
+    ESLINT_NODE_VERSION: "9.11.1"
   node:
     version: 7.9.0
 
@@ -16,7 +18,11 @@ test:
     - |
       # eslint
       if [[ "$CIRCLE_BRANCH" != "release-v"* ]]; then
+        nvm install "$ESLINT_NODE_VERSION"
+        node -v
         ./node_modules/.bin/eslint --max-warnings=0 .
+        # Restore default node version.
+        nvm use 7.9.0
       fi
     - |
       # flow


### PR DESCRIPTION
It seems that the Prettier ESLint plugin doesn't work well on Node v6/v7 and occasionally crashes and/or OOMs. We're seeing this quite frequently on CircleCI now.

see: https://github.com/prettier/prettier/issues/3457

It appears that the best workaround is to use a higher Node version when running ESLint. I was able to confirm on a Linux machine that this uses substantially less memory.