### PR TITLE
Fix .jsx extension for #1429

### DIFF
--- a/pkg/nuclide-flow/lib/main.js
+++ b/pkg/nuclide-flow/lib/main.js
@@ -144,7 +144,7 @@ async function activateLsp(): Promise<UniversalDisposable> {
         fileNotifier,
         host,
         projectFileNames: ['.flowconfig'],
-        fileExtensions: ['.js'],
+        fileExtensions: ['.js', '.jsx'],
         logCategory: 'flow-language-server',
         logLevel: 'ALL',
         additionalLogFilesRetentionPeriod: 5 * 60 * 1000, // 5 minutes

--- a/pkg/nuclide-js-imports-client/lib/main.js
+++ b/pkg/nuclide-js-imports-client/lib/main.js
@@ -59,7 +59,7 @@ async function connectToJSImportsService(
       logCategory: 'jsimports',
       logLevel: (featureConfig.get('nuclide-js-imports-client.logLevel'): any),
       projectFileNames: ['.flowconfig'],
-      fileExtensions: ['.js'],
+      fileExtensions: ['.js', '.jsx'],
       initializationOptions: getAutoImportSettings(),
       fork: true,
     },


### PR DESCRIPTION
Quick fix for the bug, which prevents using `nuclide-js-imports-client` with `.jsx` files extension. #1429