### PR TITLE
added show on cursor over for datatip

### DIFF
--- a/modules/atom-ide-ui/pkg/atom-ide-datatip/lib/DatatipManager.js
+++ b/modules/atom-ide-ui/pkg/atom-ide-datatip/lib/DatatipManager.js
@@ -254,6 +254,7 @@ class DatatipManagerForEditor {
   _interactedWith: boolean;
   _checkedScrollable: boolean;
   _isScrollable: boolean;
+  _showOnCursorOver: boolean;
 
   constructor(
     editor: atom$TextEditor,
@@ -276,6 +277,7 @@ class DatatipManagerForEditor {
     this._lastHiddenTime = 0;
     this._lastFetchedFromCursorPosition = false;
     this._shouldDropNextMouseMoveAfterFocus = false;
+    this._showOnCursorOver = false;
 
     this._subscriptions.add(
       featureConfig.observe('atom-ide-datatip.datatipDebounceDelay', () =>
@@ -285,6 +287,9 @@ class DatatipManagerForEditor {
         'atom-ide-datatip.datatipInteractedWithDebounceDelay',
         () => this._setHideIfOutsideDebounce(),
       ),
+      featureConfig.observe('atom-ide-datatip.showDatatipOnCursorOver', e => {
+        this._showOnCursorOver = e;
+      }),
       Observable.fromEvent(this._editorView, 'focus').subscribe(e => {
         this._shouldDropNextMouseMoveAfterFocus = true;
         if (!this._insideDatatip) {
@@ -343,6 +348,9 @@ class DatatipManagerForEditor {
         }
       }),
       Observable.fromEvent(this._editorView, 'keyup').subscribe(e => {
+        if (this._showOnCursorOver) {
+          this._startFetching(() => this._editor.getCursorBufferPosition());
+        }
         const modifierKey = getModifierKeyFromKeyboardEvent(e);
         if (modifierKey) {
           this._heldKeys.delete(modifierKey);

--- a/modules/atom-ide-ui/pkg/atom-ide-datatip/package.json
+++ b/modules/atom-ide-ui/pkg/atom-ide-datatip/package.json
@@ -35,6 +35,12 @@
       "description": "Display only the highest priority datatip on hover.",
       "type": "boolean",
       "default": false
+    },
+    "showDatatipOnCursorOver": {
+      "title": "Display datatip on cursor over",
+      "description": "This adds the behavior similar to atom-linter when moving the cursor over a datatip marker automatically displays the tip.",
+      "type": "boolean",
+      "default": false
     }
   },
   "providedServices": {


### PR DESCRIPTION
This pull request adds datatip on cursor while using keyboard. The setting can be turned on by going into settings.

This is the same [pull request](https://github.com/facebook-atom/atom-ide-ui/pull/307)